### PR TITLE
build: add backend/requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,12 @@
+arxiv>=3.0.0
+fastapi>=0.136.0
+httpx>=0.28.1
+numpy>=2.4.4
+openai>=2.32.0
+pdfplumber>=0.11.9
+pydantic>=2.13.3
+python-dotenv>=1.2.2
+pyyaml>=6.0.3
+requests>=2.33.1
+sentence-transformers>=5.4.1
+uvicorn>=0.45.0


### PR DESCRIPTION
## Summary
- Add `backend/requirements.txt` mirroring the runtime dependencies in `backend/pyproject.toml`
- Provides a pip-installable dependency list for environments that don't use uv

## Test plan
- [ ] `pip install -r backend/requirements.txt` resolves successfully