### PR TITLE
refactor: sage app foundations with real chat, KB UI, generation endpoints, audio, history

### DIFF
--- a/backend/api/audio.py
+++ b/backend/api/audio.py
@@ -1,0 +1,202 @@
+"""Audio generation endpoint — KB-grounded narration script + optional
+OpenAI TTS synthesis. Frontend falls back to browser SpeechSynthesis when
+no server-side audio file is produced."""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from api.generate import _empty_kb_error, _gather_context, llm_text
+from config import SageConfig
+from store.db import KnowledgeStore
+
+router = APIRouter(tags=["audio"])
+logger = logging.getLogger("sage.audio")
+
+# Words per second — used to estimate segment timings and total duration
+# when we can't probe the audio file. Roughly matches OpenAI TTS / typical
+# browser SpeechSynthesis pacing.
+WORDS_PER_SECOND = 2.5
+
+AUDIO_CACHE_DIR = Path(os.getenv("SAGE_AUDIO_CACHE", "/tmp/sage_audio"))
+AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ─────────────────────── Schemas ───────────────────────────────
+
+
+class AudioRequest(BaseModel):
+    topic: str | None = None
+    tome_id: str | None = None
+    voice: str | None = None  # OpenAI TTS voice (alloy, echo, fable, onyx, nova, shimmer)
+    provider: str | None = None
+    model: str | None = None
+
+
+# ─────────────────────── Script generation ─────────────────────
+
+
+SCRIPT_SYSTEM = """You write spoken-style narration grounded ONLY in the provided source excerpts. The output will be read aloud by a text-to-speech engine.
+
+Rules:
+- Conversational, natural prose. Like a podcast host explaining a topic.
+- No markdown, no bullet points, no code blocks, no headings, no citations.
+- Do not say "in the sources" or "according to chunk 3" — just teach the content.
+- 4–8 short paragraphs. Each paragraph 1–3 sentences.
+- Roughly 200–350 words total.
+- End with a brief closing sentence.
+- If the sources are sparse, summarize what's there honestly without inventing facts."""
+
+
+_SENTENCE_RE = re.compile(r"[^.!?\n]+[.!?]+|\S[^.!?\n]*", re.UNICODE)
+
+
+def _split_into_segments(script: str) -> list[dict[str, Any]]:
+    """Split the script into spoken sentences with estimated start/end times
+    proportional to word count."""
+    raw_sentences = [m.group(0).strip() for m in _SENTENCE_RE.finditer(script)]
+    raw_sentences = [s for s in raw_sentences if s]
+
+    if not raw_sentences:
+        return []
+
+    segments: list[dict[str, Any]] = []
+    cursor = 0.0
+    for i, text in enumerate(raw_sentences):
+        words = max(1, len(text.split()))
+        duration = max(1.2, words / WORDS_PER_SECOND)
+        segments.append({
+            "id": f"s{i + 1}",
+            "text": text,
+            "startTime": round(cursor, 2),
+            "endTime": round(cursor + duration, 2),
+        })
+        cursor += duration
+    return segments
+
+
+# ─────────────────────── TTS synthesis ─────────────────────────
+
+
+_OPENAI_TTS_VOICES = {"alloy", "echo", "fable", "onyx", "nova", "shimmer"}
+
+
+def _maybe_synthesize_openai_tts(
+    script: str, voice: str | None, config: SageConfig,
+) -> tuple[str | None, str | None]:
+    """If an OpenAI key is configured, synthesize the script to an MP3 on
+    disk and return (audio_id, voice_used). Otherwise return (None, None)
+    so the frontend can fall back to browser SpeechSynthesis."""
+    openai_cfg = config.provider_config("openai")
+    api_key = openai_cfg.get("api_key") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None, None
+
+    selected_voice = (voice or "alloy").lower()
+    if selected_voice not in _OPENAI_TTS_VOICES:
+        selected_voice = "alloy"
+
+    try:
+        # Imported lazily so missing SDK never breaks the no-TTS path.
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key, base_url=openai_cfg.get("base_url"))
+        audio_id = uuid.uuid4().hex
+        out_path = AUDIO_CACHE_DIR / f"{audio_id}.mp3"
+
+        with client.audio.speech.with_streaming_response.create(
+            model="tts-1",
+            voice=selected_voice,
+            input=script,
+        ) as response:
+            response.stream_to_file(out_path)
+
+        return audio_id, selected_voice
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("OpenAI TTS synthesis failed, falling back: %s", exc)
+        return None, None
+
+
+# ─────────────────────── Endpoints ─────────────────────────────
+
+
+@router.post("/api/generate/audio")
+async def generate_audio(
+    req: AudioRequest,
+    store: KnowledgeStore = Depends(),
+    config: SageConfig = Depends(),
+):
+    context_text, sources = await _gather_context(
+        topic=req.topic, tome_id=req.tome_id, store=store, config=config,
+        max_results=8,
+    )
+    if not context_text:
+        raise _empty_kb_error()
+
+    topic_line = (
+        f"Topic focus: {req.topic.strip()}" if req.topic and req.topic.strip()
+        else "Topic focus: cover the most important ideas in the sources."
+    )
+    user_prompt = (
+        f"{topic_line}\n"
+        f"Write the narration now.\n\n"
+        f"Source excerpts:\n{context_text}"
+    )
+
+    try:
+        script, provider_used, model_used = await llm_text(
+            SCRIPT_SYSTEM, user_prompt, req.provider, req.model, config,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("audio script generation failed")
+        raise HTTPException(status_code=502, detail=f"Failed to generate script: {exc}")
+
+    script = script.strip()
+    if not script:
+        raise HTTPException(status_code=502, detail="Model produced an empty script.")
+
+    segments = _split_into_segments(script)
+    estimated_duration = segments[-1]["endTime"] if segments else 0.0
+
+    audio_id, used_voice = _maybe_synthesize_openai_tts(script, req.voice, config)
+    audio_url = f"/api/audio/{audio_id}.mp3" if audio_id else None
+
+    voice_label = used_voice or "Browser"
+
+    title = (
+        f"Audio: {req.topic.strip()}" if req.topic and req.topic.strip()
+        else "Audio overview"
+    )
+
+    return {
+        "id": audio_id or f"local-{uuid.uuid4().hex[:8]}",
+        "title": title,
+        "voice": voice_label,
+        "provider": provider_used,
+        "model": model_used,
+        "script": script,
+        "segments": segments,
+        "duration": estimated_duration,
+        "audio_url": audio_url,
+        "sources": sources,
+        "topic": req.topic or "",
+    }
+
+
+@router.get("/api/audio/{audio_id}.mp3")
+async def get_audio_file(audio_id: str):
+    """Serve a previously-synthesized TTS file."""
+    if not re.fullmatch(r"[a-f0-9\-]{8,}", audio_id):
+        raise HTTPException(status_code=400, detail="Invalid audio id.")
+    path = AUDIO_CACHE_DIR / f"{audio_id}.mp3"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Audio file not found or expired.")
+    return FileResponse(path, media_type="audio/mpeg", filename=f"{audio_id}.mp3")

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -16,15 +16,35 @@ from store.models import Message as DBMessage
 
 router = APIRouter(prefix="/api/chat", tags=["chat"])
 
-SYSTEM_PROMPT = """You are Sage, a helpful knowledge assistant. You have access to the user's personal knowledge base through tools. When answering questions:
+SYSTEM_PROMPT = """You are Sage, a helpful knowledge assistant. You have access to the user's personal knowledge base through tools.
 
+When answering questions:
 1. Search the knowledge base first using search_docs
 2. Read relevant documents if needed using read_document
 3. Cite sources with numbered references like [1], [2]
 4. Be concise but thorough
 5. If nothing relevant is found, say so honestly
 
-Always ground your answers in the user's actual documents."""
+Always ground your answers in the user's actual documents.
+
+# App capabilities you should know about
+
+You run inside the Sage app. The app's frontend watches every message the user sends — to the command bar OR to you in chat — and routes prompts containing certain keywords to dedicated views instead of returning a chat reply. You should be aware of these so you can guide the user accurately when they ask "what can you do?" or how to access a feature. Do NOT try to render these artifacts yourself in markdown — tell the user the keyword to type and the app will open the right view.
+
+Routing keywords (case-insensitive):
+- "quiz", or whole-word "test" / "tests" / "testing" → generates a real multiple-choice quiz from the knowledge base via POST /api/generate/quiz, rendered in the QuizWidget.
+- "flashcard" / "flash card" → generates real study flashcards from the knowledge base via POST /api/generate/flashcards, rendered in the FlashcardWidget.
+- "audio", "listen", "podcast" → generates a spoken-style narration script from the knowledge base via POST /api/generate/audio. If an OpenAI API key is configured, the script is synthesized to an MP3 (OpenAI TTS) and played in an audio element; otherwise playback falls back to the browser's SpeechSynthesis voice. Transcript scrolls with the audio.
+- "report", "study guide", "summary" → opens the report view (sample report for now).
+- "history" → opens the history panel of past sessions.
+- "tome", "collection", "library" → opens the tome selector for grouping documents.
+- "knowledge", "kb", "docs", "documents", "knowledge base", "view/show/list documents" → opens the KnowledgeBaseWidget which lists every ingested document with detail + delete.
+
+Other things the user can do in this app:
+- Upload documents to the knowledge base using the circular upload button to the right of the command bar. It accepts pasted text or text-like files (.txt, .md, .csv, .json, .log). PDFs/DOCX/images are not yet supported via the UI.
+- Anything ingested is chunked, embedded, and dedup'd by content hash; you can immediately search it via search_docs.
+
+If the user asks for one of the routed features inside chat (e.g. "make me flashcards on attention"), the app will switch views automatically — you will not see the follow-up. So when that happens, you do not need to reply at all. If the user is asking *about* a feature rather than invoking it, explain it using the information above."""
 
 
 class ChatRequest(BaseModel):
@@ -33,6 +53,15 @@ class ChatRequest(BaseModel):
     tome_id: str | None = None  # Scope to this tome
     provider: str | None = None
     model: str | None = None
+
+
+@router.get("/sessions")
+async def list_sessions(
+    limit: int = 100,
+    store: KnowledgeStore = Depends(),
+):
+    """Return recent chat sessions for the History panel."""
+    return {"sessions": store.list_sessions(limit=limit)}
 
 
 @router.post("")

--- a/backend/api/generate.py
+++ b/backend/api/generate.py
@@ -1,0 +1,479 @@
+"""Generation endpoints — produce structured artifacts (flashcards, quizzes)
+grounded in the user's knowledge base."""
+from __future__ import annotations
+
+import json
+import logging
+import random
+import re
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from config import SageConfig
+from providers.base import Message
+from providers.factory import create_provider
+from skills.base import SkillContext
+from skills.search_docs import SearchDocsSkill
+from store.db import KnowledgeStore
+
+router = APIRouter(prefix="/api/generate", tags=["generate"])
+logger = logging.getLogger("sage.generate")
+
+
+# ─────────────────────── Request schemas ───────────────────────
+
+
+class GenerateRequest(BaseModel):
+    topic: str | None = None
+    tome_id: str | None = None
+    count: int = 6
+    provider: str | None = None
+    model: str | None = None
+
+
+# ─────────────────────── Shared helpers ────────────────────────
+
+
+async def _gather_context(
+    topic: str | None,
+    tome_id: str | None,
+    store: KnowledgeStore,
+    config: SageConfig,
+    max_results: int,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Return (joined context text, list of source dicts). Falls back to
+    random sampling when there's no topic to drive semantic search."""
+    if topic:
+        skill = SearchDocsSkill()
+        ctx = SkillContext(
+            store=store, provider=None, workspace=config.db_path.parent,
+            config=config, tome_id=tome_id,
+        )
+        result = await skill.execute(
+            {"query": topic, "max_results": max_results}, ctx,
+        )
+        rows = result.data.get("results", []) if result.data else []
+        if rows:
+            sources = [
+                {
+                    "document_id": r["document_id"],
+                    "document_title": r["document_title"],
+                    "chunk_index": r["chunk_index"],
+                    "similarity": r["similarity"],
+                }
+                for r in rows
+            ]
+            joined = "\n\n".join(
+                f'[{i + 1}] "{r["document_title"]}" (chunk {r["chunk_index"]})\n{r["content"]}'
+                for i, r in enumerate(rows)
+            )
+            return joined, sources
+
+    # No topic, or search returned nothing — fall back to random chunks.
+    if tome_id:
+        doc_ids = set(store.get_tome_document_ids(tome_id))
+        chunks = [c for c in store.get_all_chunks_with_embeddings() if c.document_id in doc_ids]
+    else:
+        chunks = store.get_all_chunks_with_embeddings()
+
+    if not chunks:
+        return "", []
+
+    sampled = random.sample(chunks, k=min(max_results, len(chunks)))
+    sources = []
+    parts = []
+    for i, chunk in enumerate(sampled, 1):
+        doc = store.get_document(chunk.document_id)
+        title = doc.title if doc else "Unknown"
+        sources.append({
+            "document_id": chunk.document_id,
+            "document_title": title,
+            "chunk_index": chunk.chunk_index,
+            "similarity": None,
+        })
+        parts.append(f'[{i}] "{title}" (chunk {chunk.chunk_index})\n{chunk.content}')
+    return "\n\n".join(parts), sources
+
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _extract_json(text: str) -> Any:
+    """Pull a JSON object out of a model response that may be wrapped in
+    prose or code fences. Raises ValueError if nothing parses."""
+    candidates: list[str] = []
+    candidates.extend(m.group(1).strip() for m in _JSON_FENCE_RE.finditer(text))
+
+    stripped = text.strip()
+    if stripped:
+        candidates.append(stripped)
+
+    for start_ch, end_ch in (("{", "}"), ("[", "]")):
+        first = text.find(start_ch)
+        last = text.rfind(end_ch)
+        if first != -1 and last > first:
+            candidates.append(text[first : last + 1])
+
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    raise ValueError("Could not parse JSON from model response")
+
+
+async def _llm_json(
+    system_prompt: str,
+    user_prompt: str,
+    provider_name: str | None,
+    model: str | None,
+    config: SageConfig,
+) -> Any:
+    provider_name = provider_name or config.get("providers.default", "ollama")
+    provider_config = config.provider_config(provider_name)
+    resolved_model = model or provider_config.get("default_model", "llama3.1:8b")
+    provider = create_provider(provider_name, provider_config)
+
+    kwargs: dict[str, Any] = {}
+    if provider_name in ("openai", "deepseek"):
+        kwargs["response_format"] = {"type": "json_object"}
+
+    messages = [
+        Message(role="system", content=system_prompt),
+        Message(role="user", content=user_prompt),
+    ]
+    response = await provider.chat(messages=messages, tools=[], model=resolved_model, **kwargs)
+    text = getattr(response, "content", "") or ""
+    return _extract_json(text)
+
+
+async def llm_text(
+    system_prompt: str,
+    user_prompt: str,
+    provider_name: str | None,
+    model: str | None,
+    config: SageConfig,
+) -> tuple[str, str, str]:
+    """Call the configured provider with no tools, no JSON-mode. Returns
+    (content, resolved_provider_name, resolved_model)."""
+    provider_name = provider_name or config.get("providers.default", "ollama")
+    provider_config = config.provider_config(provider_name)
+    resolved_model = model or provider_config.get("default_model", "llama3.1:8b")
+    provider = create_provider(provider_name, provider_config)
+
+    messages = [
+        Message(role="system", content=system_prompt),
+        Message(role="user", content=user_prompt),
+    ]
+    response = await provider.chat(messages=messages, tools=[], model=resolved_model)
+    return (getattr(response, "content", "") or "", provider_name, resolved_model)
+
+
+def _empty_kb_error() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail=(
+            "Your knowledge base is empty for this scope. Add documents first "
+            "via the upload button next to the command bar."
+        ),
+    )
+
+
+# ─────────────────────── Flashcards ────────────────────────────
+
+
+FLASHCARD_SYSTEM = """You write study flashcards grounded ONLY in the provided source excerpts.
+
+Rules:
+- Each card must be answerable from the sources. Do not invent facts.
+- "front" is a concise question or term (1 sentence).
+- "back" is a tight, self-contained answer (1–3 sentences).
+- Cover distinct ideas — do not repeat the same fact in different words.
+- Output ONLY a JSON object of the form: {"cards": [{"front": "...", "back": "..."}, ...]}
+- No commentary, no markdown fences."""
+
+
+@router.post("/flashcards")
+async def generate_flashcards(
+    req: GenerateRequest,
+    store: KnowledgeStore = Depends(),
+    config: SageConfig = Depends(),
+):
+    count = max(1, min(req.count, 20))
+    context_text, sources = await _gather_context(
+        topic=req.topic, tome_id=req.tome_id, store=store, config=config,
+        max_results=max(count, 6),
+    )
+    if not context_text:
+        raise _empty_kb_error()
+
+    topic_line = (
+        f"Topic focus: {req.topic.strip()}" if req.topic and req.topic.strip()
+        else "Topic focus: cover the most important ideas in the sources."
+    )
+    user_prompt = (
+        f"{topic_line}\n"
+        f"Generate exactly {count} flashcards.\n\n"
+        f"Source excerpts:\n{context_text}"
+    )
+
+    try:
+        parsed = await _llm_json(FLASHCARD_SYSTEM, user_prompt, req.provider, req.model, config)
+    except ValueError as exc:
+        logger.exception("flashcard json parse failed")
+        raise HTTPException(status_code=502, detail=f"Model returned unparseable output: {exc}")
+
+    raw_cards = parsed.get("cards") if isinstance(parsed, dict) else parsed
+    if not isinstance(raw_cards, list):
+        raise HTTPException(status_code=502, detail="Model output missing 'cards' array")
+
+    cards = []
+    for entry in raw_cards[:count]:
+        if not isinstance(entry, dict):
+            continue
+        front = str(entry.get("front", "")).strip()
+        back = str(entry.get("back", "")).strip()
+        if not front or not back:
+            continue
+        cards.append({"id": f"fc-{uuid.uuid4().hex[:8]}", "front": front, "back": back})
+
+    if not cards:
+        raise HTTPException(status_code=502, detail="Model produced no usable flashcards")
+
+    return {
+        "cards": cards,
+        "topic": req.topic or "",
+        "sources": sources,
+    }
+
+
+# ─────────────────────── Quiz ──────────────────────────────────
+
+
+QUIZ_SYSTEM = """You write multiple-choice quiz questions grounded ONLY in the provided source excerpts.
+
+Rules:
+- Each question must be answerable from the sources. Do not invent facts.
+- Exactly 4 options per question, labeled "a", "b", "c", "d".
+- Exactly one correct option per question.
+- "explanation" should be 1–2 sentences explaining the correct answer using the sources.
+- Distractors must be plausible but clearly wrong given the sources.
+- Output ONLY a JSON object of the form:
+  {"questions": [
+    {"question": "...",
+     "options": [{"id":"a","text":"..."},{"id":"b","text":"..."},{"id":"c","text":"..."},{"id":"d","text":"..."}],
+     "correctOptionId": "b",
+     "explanation": "..."}
+  ]}
+- No commentary, no markdown fences."""
+
+
+@router.post("/quiz")
+async def generate_quiz(
+    req: GenerateRequest,
+    store: KnowledgeStore = Depends(),
+    config: SageConfig = Depends(),
+):
+    count = max(1, min(req.count, 15))
+    context_text, sources = await _gather_context(
+        topic=req.topic, tome_id=req.tome_id, store=store, config=config,
+        max_results=max(count, 5),
+    )
+    if not context_text:
+        raise _empty_kb_error()
+
+    topic_line = (
+        f"Topic focus: {req.topic.strip()}" if req.topic and req.topic.strip()
+        else "Topic focus: cover the most important ideas in the sources."
+    )
+    user_prompt = (
+        f"{topic_line}\n"
+        f"Generate exactly {count} multiple-choice questions.\n\n"
+        f"Source excerpts:\n{context_text}"
+    )
+
+    try:
+        parsed = await _llm_json(QUIZ_SYSTEM, user_prompt, req.provider, req.model, config)
+    except ValueError as exc:
+        logger.exception("quiz json parse failed")
+        raise HTTPException(status_code=502, detail=f"Model returned unparseable output: {exc}")
+
+    raw_questions = parsed.get("questions") if isinstance(parsed, dict) else parsed
+    if not isinstance(raw_questions, list):
+        raise HTTPException(status_code=502, detail="Model output missing 'questions' array")
+
+    questions = []
+    for entry in raw_questions[:count]:
+        if not isinstance(entry, dict):
+            continue
+        question_text = str(entry.get("question", "")).strip()
+        options_raw = entry.get("options")
+        correct_id = str(entry.get("correctOptionId", "")).strip().lower()
+        explanation = str(entry.get("explanation", "")).strip()
+        if not question_text or not isinstance(options_raw, list) or len(options_raw) < 2:
+            continue
+
+        options = []
+        for opt in options_raw:
+            if not isinstance(opt, dict):
+                continue
+            opt_id = str(opt.get("id", "")).strip().lower()
+            opt_text = str(opt.get("text", "")).strip()
+            if opt_id and opt_text:
+                options.append({"id": opt_id, "text": opt_text})
+        if len(options) < 2 or not any(o["id"] == correct_id for o in options):
+            continue
+
+        questions.append({
+            "id": f"q-{uuid.uuid4().hex[:8]}",
+            "question": question_text,
+            "options": options,
+            "correctOptionId": correct_id,
+            "explanation": explanation,
+        })
+
+    if not questions:
+        raise HTTPException(status_code=502, detail="Model produced no usable questions")
+
+    return {
+        "questions": questions,
+        "topic": req.topic or "",
+        "sources": sources,
+    }
+
+
+# ─────────────────────── Report ────────────────────────────────
+
+
+REPORT_SYSTEM = """You write structured study reports grounded ONLY in the provided source excerpts.
+
+Rules:
+- Every claim must be supported by the sources. Do not invent facts, numbers, or citations.
+- Aim for 5–9 sections, each focused on one distinct idea.
+- The first section MUST be "Executive Summary".
+- Section content is GitHub-flavored markdown. You may use:
+  * paragraphs, **bold**, *italic*, blockquotes
+  * bullet and numbered lists
+  * tables (pipe syntax)
+  * fenced code blocks (with language) when sources include code
+  * LaTeX math: inline `$...$` and display `$$...$$` (escape backslashes as needed)
+- Do NOT include the section title inside the section's content — only the body.
+- Do NOT use h1 (#) headings. If you need a sub-heading inside a section, use h3 (###).
+- Output ONLY a JSON object of the form:
+  {
+    "title": "Short report title (≤ 60 chars)",
+    "subtitle": "One-line description of the report's scope",
+    "sections": [
+      {"title": "Executive Summary", "content": "markdown..."},
+      {"title": "...", "content": "markdown..."},
+      ...
+    ]
+  }
+- No commentary, no markdown fences around the JSON."""
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    """Match rehype-slug / github-slugger output for typical ASCII headings."""
+    slug = _SLUG_RE.sub("-", text.lower()).strip("-")
+    return slug or "section"
+
+
+@router.post("/report")
+async def generate_report(
+    req: GenerateRequest,
+    store: KnowledgeStore = Depends(),
+    config: SageConfig = Depends(),
+):
+    context_text, sources = await _gather_context(
+        topic=req.topic, tome_id=req.tome_id, store=store, config=config,
+        max_results=10,
+    )
+    if not context_text:
+        raise _empty_kb_error()
+
+    topic_line = (
+        f"Topic focus: {req.topic.strip()}" if req.topic and req.topic.strip()
+        else "Topic focus: synthesize the most important ideas across the sources."
+    )
+    user_prompt = (
+        f"{topic_line}\n"
+        f"Write the report now as structured JSON.\n\n"
+        f"Source excerpts:\n{context_text}"
+    )
+
+    try:
+        parsed = await _llm_json(REPORT_SYSTEM, user_prompt, req.provider, req.model, config)
+    except ValueError as exc:
+        logger.exception("report json parse failed")
+        raise HTTPException(status_code=502, detail=f"Model returned unparseable output: {exc}")
+
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=502, detail="Model output was not a JSON object")
+
+    title = str(parsed.get("title", "")).strip() or (
+        f"Report: {req.topic.strip()}" if req.topic and req.topic.strip() else "Report"
+    )
+    subtitle = str(parsed.get("subtitle", "")).strip() or None
+    raw_sections = parsed.get("sections")
+    if not isinstance(raw_sections, list) or not raw_sections:
+        raise HTTPException(status_code=502, detail="Model output missing 'sections' array")
+
+    toc: list[dict[str, str]] = []
+    content_parts: list[str] = []
+    used_slugs: set[str] = set()
+    for entry in raw_sections:
+        if not isinstance(entry, dict):
+            continue
+        section_title = str(entry.get("title", "")).strip()
+        section_body = str(entry.get("content", "")).strip()
+        if not section_title or not section_body:
+            continue
+        base_slug = _slugify(section_title)
+        slug = base_slug
+        i = 1
+        while slug in used_slugs:
+            i += 1
+            slug = f"{base_slug}-{i}"
+        used_slugs.add(slug)
+        toc.append({"id": slug, "title": section_title})
+        content_parts.append(f"## {section_title}\n\n{section_body}")
+
+    if not toc:
+        raise HTTPException(status_code=502, detail="Model produced no usable sections")
+
+    unique_doc_ids: set[str] = set()
+    for s in sources:
+        unique_doc_ids.add(s["document_id"])
+    doc_count = len(unique_doc_ids)
+
+    tome_name: str | None = None
+    if req.tome_id:
+        tome = store.get_tome(req.tome_id)
+        if tome:
+            tome_name = tome.name
+
+    if doc_count:
+        if tome_name:
+            source_docs = f'Based on {doc_count} document{"s" if doc_count != 1 else ""} in "{tome_name}" tome'
+        else:
+            source_docs = f'Based on {doc_count} document{"s" if doc_count != 1 else ""} in your knowledge base'
+    else:
+        source_docs = None
+
+    content = "\n\n".join(content_parts) + "\n\n---\n\n*Report generated by Sage*"
+
+    return {
+        "title": title,
+        "subtitle": subtitle,
+        "sourceDocs": source_docs,
+        "toc": toc,
+        "content": content,
+        "sources": sources,
+        "topic": req.topic or "",
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ def _get_arxiv_service():
 from services.pdf import PDFService
 from services.summarizer import DeepSeekService
 
-from api import chat, knowledge, skills as skills_api, tomes as tomes_api
+from api import audio, chat, generate, knowledge, skills as skills_api, tomes as tomes_api
 from config import SageConfig
 from skills.read_document import ReadDocumentSkill
 from skills.registry import SkillRegistry
@@ -57,6 +57,8 @@ app.include_router(knowledge.router)
 app.include_router(chat.router)
 app.include_router(tomes_api.router)
 app.include_router(skills_api.router)
+app.include_router(generate.router)
+app.include_router(audio.router)
 # --- end Sage setup ---
 
 # Add CORS middleware with configurable origins
@@ -70,7 +72,7 @@ app.add_middleware(
 )
 
 # Initialize services
-arxiv_service = ArxivService()
+arxiv_service = _get_arxiv_service()
 
 # Thread pool for parallel processing
 executor = ThreadPoolExecutor(max_workers=5)
@@ -306,6 +308,15 @@ def download_and_extract(paper_id: str):
 @app.get("/")
 def read_root():
     return {"message": "Welcome to the Sage API!"}
+
+
+@app.get("/api/config")
+def get_config(config: SageConfig = Depends()):
+    """Expose the active provider/model so the UI can label which one's in use."""
+    provider_name = config.get("providers.default", "ollama")
+    provider_config = config.provider_config(provider_name)
+    model = provider_config.get("default_model", "")
+    return {"provider": provider_name, "model": model}
 
 
 # Clear caches endpoint (for maintenance)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,12 @@
+arxiv>=3.0.0
+fastapi>=0.136.0
+httpx>=0.28.1
+numpy>=2.4.4
+openai>=2.32.0
+pdfplumber>=0.11.9
+pydantic>=2.13.3
+python-dotenv>=1.2.2
+pyyaml>=6.0.3
+requests>=2.33.1
+sentence-transformers>=5.4.1
+uvicorn>=0.45.0

--- a/backend/store/db.py
+++ b/backend/store/db.py
@@ -231,6 +231,53 @@ class KnowledgeStore:
         self.conn.commit()
         return s
 
+    def list_sessions(self, limit: int = 100) -> list[dict]:
+        """List chat sessions with a derived title, tome name, and activity timestamps.
+
+        Returns rows shaped for the History panel — newest activity first."""
+        rows = self.conn.execute(
+            """
+            SELECT
+                s.id                AS id,
+                s.tome_id           AS tome_id,
+                s.provider          AS provider,
+                s.model             AS model,
+                s.created_at        AS created_at,
+                t.name              AS tome_name,
+                (SELECT content FROM messages
+                   WHERE session_id = s.id AND role = 'user'
+                   ORDER BY created_at ASC LIMIT 1) AS first_user_message,
+                (SELECT created_at FROM messages
+                   WHERE session_id = s.id
+                   ORDER BY created_at DESC LIMIT 1) AS last_message_at,
+                (SELECT COUNT(*) FROM messages
+                   WHERE session_id = s.id) AS message_count
+            FROM sessions s
+            LEFT JOIN tomes t ON t.id = s.tome_id
+            ORDER BY COALESCE(
+                (SELECT created_at FROM messages
+                   WHERE session_id = s.id ORDER BY created_at DESC LIMIT 1),
+                s.created_at
+            ) DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [
+            {
+                "id": r["id"],
+                "tome_id": r["tome_id"],
+                "tome_name": r["tome_name"],
+                "provider": r["provider"],
+                "model": r["model"],
+                "created_at": r["created_at"],
+                "last_message_at": r["last_message_at"] or r["created_at"],
+                "first_user_message": r["first_user_message"],
+                "message_count": r["message_count"] or 0,
+            }
+            for r in rows
+        ]
+
     def get_tome_session(self, tome_id: str) -> Optional[Session]:
         """Get the most recent session for a tome."""
         row = self.conn.execute(

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Sage docs
+
+Reference notes for changes made on this branch (`add-backend-requirements-txt`)
+since the last commit on `main` (`92b46c8 build: add backend/requirements.txt`).
+Each file documents one feature area: what was added, where it lives, and how
+to use it.
+
+## Contents
+
+- [agentation-install.md](./agentation-install.md) — installing the Agentation
+  dev panel in the Next.js app.
+- [chat-backend-integration.md](./chat-backend-integration.md) — wiring
+  `ChatWidget` to the live `/api/chat` endpoint (replaces the simulated reply).
+- [knowledge-base-ui.md](./knowledge-base-ui.md) — the upload modal next to the
+  command bar and the `KnowledgeBaseWidget` for browsing ingested documents.
+- [in-chat-command-routing.md](./in-chat-command-routing.md) — shared verb
+  detection so the command bar *and* the chat input both route "quiz",
+  "flashcards", "knowledge", etc. to the right view.
+- [generation-endpoints.md](./generation-endpoints.md) — backend
+  `/api/generate/flashcards` and `/api/generate/quiz` plus the
+  `FlashcardsView` / `QuizView` wrappers that consume them.
+- [audio-generation.md](./audio-generation.md) — `/api/generate/audio`
+  narration scripts, OpenAI TTS synthesis, and the dual-mode
+  `AudioPlayerWidget` (`<audio>` element when TTS is available, browser
+  `SpeechSynthesis` otherwise).
+
+## Conventions used here
+
+- File paths are relative to the repository root.
+- Code snippets are illustrative — read the actual files for current source of
+  truth; this folder documents intent and shape, not exhaustive APIs.
+- Each doc has a **Files touched** list at the bottom so reviewers can map
+  features to diffs quickly.

--- a/docs/agentation.md
+++ b/docs/agentation.md
@@ -1,0 +1,38 @@
+# Agentation dev panel
+
+Added the [Agentation](https://www.agentation.com/install) overlay so feedback
+posted from the running app surfaces in this Claude Code session via the
+`mcp__agentation__*` tool family.
+
+## What it does
+
+- `npm install agentation -D` was run inside `frontend/`.
+- A small client wrapper (`AgentationDev`) renders `<Agentation />` only when
+  `process.env.NODE_ENV === "development"`, so the overlay never ships in a
+  production build.
+- The wrapper is mounted at the end of `<body>` in the root layout, after
+  `{children}`, to keep its DOM out of the app tree.
+
+## Files touched
+
+- `frontend/package.json` — added `agentation` to `devDependencies`.
+- `frontend/src/components/AgentationDev.tsx` — new, dev-only wrapper.
+- `frontend/src/app/layout.tsx` — imports and renders `<AgentationDev />`.
+
+## Optional MCP server
+
+The npm package exposes a UI overlay only. To expose the agent feedback bridge
+to a CLI agent (Claude Code), the user runs the MCP install separately —
+this repo does not commit the server config:
+
+```
+npx agentation-mcp init      # interactive setup
+npx agentation-mcp doctor    # verify
+```
+
+The default MCP server listens on `http://localhost:4747`. If you want the
+React panel to talk to a non-default endpoint, pass it explicitly:
+
+```tsx
+<Agentation endpoint="http://localhost:4747" />
+```

--- a/docs/audio-generation.md
+++ b/docs/audio-generation.md
@@ -1,0 +1,167 @@
+# Audio (TTS) generation
+
+The audio view used to render a hard-coded `SAMPLE_TRACK` and fake playback
+with a `setInterval` timer. It now generates a real, KB-grounded narration
+script and plays actual audio.
+
+## End-to-end flow
+
+1. User types something containing `audio`, `listen`, or `podcast` (in the
+   command bar or in chat). The prompt is captured as `generationPrompt`.
+2. `<AudioView prompt={generationPrompt} />` renders a loading card and
+   `POST`s to `/api/generate/audio`.
+3. Backend retrieves KB chunks (semantic search if a topic is given, random
+   sample otherwise — same helper as flashcards/quiz), prompts the configured
+   provider for a spoken-style script, and splits it into sentence segments
+   with estimated timings (~2.5 words/sec).
+4. If an OpenAI API key is configured, the backend also synthesizes the
+   script to an MP3 via OpenAI TTS (`tts-1`) and caches it to disk; the
+   response includes `audio_url: "/api/audio/{id}.mp3"`.
+5. If no key is configured, `audio_url` is `null` and the frontend falls
+   back to the browser's `SpeechSynthesis` API for playback.
+6. `AudioPlayerWidget` plays the real `<audio>` element or speaks via
+   `SpeechSynthesis`, advances the transcript highlight in lockstep, and
+   updates the "Download" affordance accordingly.
+
+## Backend
+
+### `POST /api/generate/audio`
+
+Request:
+
+```json
+{
+  "topic": "string | null",
+  "tome_id": "string | null",
+  "voice": "alloy | echo | fable | onyx | nova | shimmer | null",
+  "provider": "string | null",
+  "model":    "string | null"
+}
+```
+
+Response:
+
+```json
+{
+  "id":       "<audio_id or local-…>",
+  "title":   "Audio: <topic>",
+  "voice":    "alloy" | "Browser",
+  "provider": "<resolved>",
+  "model":    "<resolved>",
+  "script":   "Full narration…",
+  "segments": [{"id":"s1","text":"…","startTime":0.0,"endTime":4.4}, …],
+  "duration": 217.8,
+  "audio_url": "/api/audio/<id>.mp3" | null,
+  "sources":  [{"document_id":"…","document_title":"…","chunk_index":3,
+                "similarity":0.81}, …],
+  "topic":    "<echoed>"
+}
+```
+
+- Segments are produced by a simple sentence regex; durations are
+  proportional to word count. They are not word-accurate but are good
+  enough for transcript scroll-lock.
+- `voice` is the OpenAI TTS voice that was used. Defaults to `alloy`.
+  Unknown voices are coerced to `alloy`. When no OpenAI key is present,
+  the response labels it `Browser` so the UI can show a "Browser TTS"
+  badge in place of the Download button.
+
+### `GET /api/audio/{audio_id}.mp3`
+
+Streams a previously-synthesized file from
+`SAGE_AUDIO_CACHE` (defaults to `/tmp/sage_audio`). The id is validated
+against `[a-f0-9-]{8,}` to keep the route from being abused as a
+directory traversal.
+
+### Empty KB
+
+Same behavior as the other generation endpoints: if the user's KB (or the
+scoped tome) has no chunks, the endpoint returns `400` with a pointer to
+the upload button.
+
+### Helper reuse
+
+`backend/api/audio.py` imports `_gather_context` and `_empty_kb_error`
+from `backend/api/generate.py` (the underscore is a hint, not a hard
+boundary). A new `llm_text(...)` helper in `generate.py` does a plain
+content-only completion (no JSON-mode), used by audio for the narration
+script.
+
+## Frontend
+
+### `AudioPlayerWidget`
+
+Two new props:
+
+- `audioUrl?: string | null` — when set, a hidden `<audio>` element is
+  rendered and used as the playback source of truth (`timeupdate` /
+  `ended` events drive `currentTime` and `isPlaying`).
+- `script?: string` — full narration text. Used by the
+  `SpeechSynthesis` fallback so it can speak the remaining text after a
+  seek (it can't restart mid-utterance).
+
+Playback semantics differ a bit between the two modes:
+
+|                   | `<audio>` mode                  | SpeechSynthesis mode              |
+|-------------------|---------------------------------|------------------------------------|
+| Play / pause      | `el.play()` / `el.pause()`      | `synth.speak()` / `synth.cancel()` |
+| Seek bar          | Sets `el.currentTime`           | Cancels and restarts speech from the nearest segment |
+| ±15s buttons      | Same as seek                    | Same as seek                       |
+| Transcript timing | Driven by `timeupdate`          | Driven by a 100ms interval and word-count-based segment times |
+| Footer affordance | `<a download>` for the MP3      | "Browser TTS" pill                 |
+
+### `AudioView`
+
+Same shape as the existing `FlashcardsView` / `QuizView` — loading,
+error-with-retry, and success states. The sources footer lists distinct
+source document titles.
+
+### API client
+
+`generateAudio({ topic, tomeId, voice, provider, model })` in
+`frontend/src/lib/sage-api.ts` returns an `AudioGeneration`. A small
+`resolveAudioUrl(path)` helper joins the relative audio path with the
+active API base (so it works both from the Next.js dev server hitting
+`http://localhost:8000` and the Tauri sidecar on `http://127.0.0.1:8080`).
+
+## Limitations
+
+- Word-level subtitle accuracy isn't possible from `/v1/audio/speech`;
+  segment timings are an estimate. They're tightly correlated to the
+  actual playback rate for `tts-1`, but a long sentence with technical
+  jargon will lag slightly.
+- The MP3 cache is on local disk (`/tmp/sage_audio` by default). Nothing
+  evicts it — fine for dev, but a long-running deployment will want a
+  TTL / size cap.
+- No streaming yet: the user waits for the script to finish generating
+  *and* the MP3 to finish synthesizing before playback can start. Could
+  be split into "play once script is ready (SpeechSynthesis)" while the
+  MP3 synthesizes in the background, but that's a follow-up.
+
+## Files touched
+
+### Backend
+
+- `backend/api/audio.py` (new) — narration + TTS endpoints.
+- `backend/api/generate.py` — added `llm_text(...)` helper.
+- `backend/api/chat.py` — updated the "audio" capability description in
+  the system prompt so the agent stops calling it a sample track.
+- `backend/main.py` — `include_router(audio.router)`.
+
+### Frontend
+
+- `frontend/src/components/AudioPlayerWidget.tsx` — added `audioUrl` and
+  `script` props, real `<audio>` mode, SpeechSynthesis fallback,
+  conditional Download / Browser-TTS badge.
+- `frontend/src/components/AudioView.tsx` (new) — fetch wrapper with
+  loading/error states and source footer.
+- `frontend/src/lib/sage-api.ts` — added `generateAudio`, `AudioGeneration`,
+  `AudioSegment`, `resolveAudioUrl`.
+- `frontend/src/app/page.tsx` — uses `<AudioView />` in the audio view-state;
+  audio prompts are stored in `generationPrompt` like flashcards/quiz.
+
+## How to enable server-side TTS
+
+Set `OPENAI_API_KEY` in the backend's environment (or `openai.api_key` in
+`SageConfig`). The endpoint will automatically synthesize MP3s; otherwise
+playback uses the browser voice with no extra setup.

--- a/docs/chat-backend-integration.md
+++ b/docs/chat-backend-integration.md
@@ -1,0 +1,47 @@
+# Chat backend integration
+
+`ChatWidget` previously faked replies with a `setTimeout` that echoed the
+user's message back. It now drives a real round-trip against the FastAPI
+`/api/chat` endpoint via the existing `sendChat()` helper in
+`frontend/src/lib/sage-api.ts`.
+
+## Behavior
+
+- The widget tracks a `sessionId` returned from the first request and reuses
+  it on follow-up turns, so the backend can persist the conversation in
+  `KnowledgeStore`.
+- The typing indicator now reflects actual backend latency instead of a
+  hard-coded 1.5s delay.
+- Backend errors are surfaced inline as an assistant-style message
+  (`**Error reaching backend:** …`) instead of being swallowed.
+- A new `initialQuery` prop lets the parent auto-send a prompt on mount —
+  this is how `page.tsx` forwards the user's first command-bar query into
+  the chat view.
+- Optional `tomeId` / `provider` / `model` props pass through to `sendChat`
+  for future tome-aware UI.
+
+## Provider/model badge
+
+`ChatWidget` and `CommandBar` both call `getRuntimeConfig()`
+(`GET /api/config`) on mount to label the current provider/model in the
+header pill, instead of the hard-coded "GPT-4o" string.
+
+## Files touched
+
+- `frontend/src/components/ChatWidget.tsx` — replaced simulated reply with
+  `sendChat()`, added session/loading/error state, `initialQuery`,
+  `onCommand` (see [in-chat-command-routing.md](./in-chat-command-routing.md)).
+- `frontend/src/components/CommandBar.tsx` — model label is now driven by
+  `getRuntimeConfig()`.
+- `frontend/src/app/page.tsx` — tracks the user's command-bar prompt and
+  forwards it to `ChatWidget` as `initialQuery`.
+
+## Running locally
+
+1. Backend: `cd backend && python main.py` (defaults to port 8000).
+2. Frontend: `cd frontend && npm run dev` (defaults to port 3000).
+
+CORS for `http://localhost:3000` is already allowed in `backend/main.py`.
+The `/api/chat` endpoint uses whichever provider is configured as
+`providers.default` in `SageConfig` (Ollama by default); see
+`backend/config.py` for the per-provider settings.

--- a/docs/generation-endpoints.md
+++ b/docs/generation-endpoints.md
@@ -1,0 +1,143 @@
+# Generation endpoints: flashcards & quizzes
+
+Previously `FlashcardWidget` and `QuizWidget` rendered hard-coded
+`SAMPLE_FLASHCARDS` / `SAMPLE_QUESTIONS` regardless of what the user typed.
+Two new backend endpoints generate real artifacts grounded in the knowledge
+base, and two new view wrappers (`FlashcardsView`, `QuizView`) consume them.
+
+## Backend: `backend/api/generate.py`
+
+Single router mounted at `/api/generate`, registered from
+`backend/main.py`.
+
+### `POST /api/generate/flashcards`
+
+Request body (all fields optional except by validation):
+
+```json
+{
+  "topic": "string | null",
+  "tome_id": "string | null",
+  "count": 6,
+  "provider": "string | null",
+  "model":    "string | null"
+}
+```
+
+Response:
+
+```json
+{
+  "cards": [{"id": "fc-…", "front": "…", "back": "…"}],
+  "topic": "…",
+  "sources": [
+    {"document_id": "…", "document_title": "…", "chunk_index": 0,
+     "similarity": 0.812}
+  ]
+}
+```
+
+`count` is clamped to `[1, 20]`.
+
+### `POST /api/generate/quiz`
+
+Same request shape. Response:
+
+```json
+{
+  "questions": [
+    {"id": "q-…",
+     "question": "…",
+     "options": [{"id":"a","text":"…"}, …],
+     "correctOptionId": "b",
+     "explanation": "…"}
+  ],
+  "topic": "…",
+  "sources": [ … ]
+}
+```
+
+`count` is clamped to `[1, 15]`. Each question is validated to have ≥2
+options and a `correctOptionId` matching one of them; questions that fail
+validation are dropped before responding.
+
+### How grounding works
+
+`_gather_context()` decides what excerpts to feed the model:
+
+1. If `topic` is non-empty, it runs the existing `SearchDocsSkill` (semantic
+   search over chunk embeddings, optionally scoped to the tome) and uses
+   the top results.
+2. If no topic — or the semantic search returned nothing — it falls back to
+   a random sample of chunks from the tome (or the whole KB if no tome is
+   set). This is what lets a bare "make flashcards" command still work.
+3. If the KB has zero chunks in scope, the endpoint returns `400` with a
+   hint to upload documents first.
+
+### How the JSON is produced
+
+`_llm_json()` calls the configured provider via `providers/factory.py`
+with no tools and a strongly-worded system prompt. For OpenAI-compatible
+providers (`openai`, `deepseek`) it also passes
+`response_format={"type": "json_object"}`. The model output is then run
+through `_extract_json()`, which tries (in order):
+
+1. Any ` ```json … ``` ` fenced blocks.
+2. The whole stripped response.
+3. The widest `{ … }` or `[ … ]` substring.
+
+If nothing parses, the endpoint returns `502` with the parser error so
+the UI can surface a useful retry.
+
+## Frontend wrappers
+
+- `frontend/src/components/FlashcardsView.tsx` — calls `generateFlashcards`,
+  shows a loading card, an error card with retry, or `FlashcardWidget`
+  with the real cards. Appends a "Grounded in:" footer listing distinct
+  source document titles.
+- `frontend/src/components/QuizView.tsx` — mirror of the above for
+  `generateQuiz` + `QuizWidget`.
+
+`page.tsx` renders these instead of the original widgets in the
+`"flashcards"` / `"quiz"` view-states, passing the user's command text in
+as `prompt`. The same `prompt` is captured whether the user invoked the
+verb from the command bar or from inside the chat (see
+[in-chat-command-routing.md](./in-chat-command-routing.md)).
+
+### API client
+
+`frontend/src/lib/sage-api.ts` exposes:
+
+- `generateFlashcards(opts)` → `FlashcardGeneration`
+- `generateQuiz(opts)` → `QuizGeneration`
+
+Both share `GenerateOpts = { topic?, tomeId?, count?, provider?, model? }`
+and `GeneratedSource` shape.
+
+## Limitations
+
+- Generation latency depends entirely on the configured provider/model. The
+  defaults (`ollama` + `llama3.1:8b`) need a local Ollama server running;
+  if it's unreachable the error surfaces in the view's error card.
+- The "topic" is currently the verbatim command string ("make flashcards on
+  attention"). The model is told what to do via the system prompt, so this
+  works, but a smarter parse (e.g., stripping the verb) would tighten the
+  retrieval query.
+- No persistence yet — generated flashcards and quizzes only live in the
+  view's React state and are regenerated on every visit.
+
+## Files touched
+
+### Backend
+
+- `backend/api/generate.py` (new) — router with both endpoints.
+- `backend/main.py` — import + `include_router(generate.router)`.
+
+### Frontend
+
+- `frontend/src/lib/sage-api.ts` — added `generateFlashcards`,
+  `generateQuiz`, and matching types.
+- `frontend/src/components/FlashcardsView.tsx` (new).
+- `frontend/src/components/QuizView.tsx` (new).
+- `frontend/src/app/page.tsx` — uses the new view wrappers; tracks
+  `generationPrompt`; added `\btest(s|ing)?\b` to the quiz route.

--- a/docs/history-panel.md
+++ b/docs/history-panel.md
@@ -1,0 +1,81 @@
+# History panel
+
+The history view (`HistoryPanel.tsx`) used to render a hard-coded
+`SAMPLE_HISTORY` array. It now reads live chat-session data from the
+backend so every conversation the user has had with Sage shows up here.
+
+## Data flow
+
+```
+HistoryPanel ──▶ listChatSessions()      (src/lib/sage-api.ts)
+              ──▶ GET /api/chat/sessions (backend/api/chat.py)
+              ──▶ KnowledgeStore.list_sessions()
+                      (backend/store/db.py — SQL over sessions + messages + tomes)
+```
+
+## Backend
+
+### `KnowledgeStore.list_sessions(limit=100)`
+
+Single SQL query over `sessions`, `messages`, and `tomes`. For each
+session it returns:
+
+| field                | source                                              |
+| -------------------- | --------------------------------------------------- |
+| `id`                 | `sessions.id`                                       |
+| `tome_id`            | `sessions.tome_id`                                  |
+| `tome_name`          | `tomes.name` via `LEFT JOIN`                        |
+| `provider`, `model`  | `sessions.provider`, `sessions.model`               |
+| `created_at`         | `sessions.created_at`                               |
+| `first_user_message` | earliest `messages.content` with `role='user'`      |
+| `last_message_at`    | most recent `messages.created_at` (or session ts)   |
+| `message_count`      | `COUNT(*)` of messages in the session               |
+
+Results are sorted by `last_message_at DESC` so the freshest activity
+appears first.
+
+### `GET /api/chat/sessions?limit=<n>`
+
+Thin FastAPI wrapper around `list_sessions`. Returns
+`{ "sessions": [...] }`. Default `limit` is 100, the same as the store.
+
+## Frontend
+
+### `listChatSessions()` (src/lib/sage-api.ts)
+
+Typed client wrapper that returns `ChatSessionSummary[]`. The shape
+mirrors the backend dict exactly.
+
+### `HistoryPanel` (src/components/HistoryPanel.tsx)
+
+- On mount, fetches up to 200 sessions.
+- Filters out sessions with `message_count === 0` or no
+  `first_user_message` — those are stub sessions created by the chat
+  endpoint that never received a user turn.
+- Derives a row title from the first user message (truncated to 90
+  chars, first line only).
+- Groups rows into "Today", "Yesterday", "Earlier this week", "Older"
+  buckets using local time. The bucket label and per-row timestamp
+  share a single `formatTimestamp` helper so they stay consistent.
+- Search input filters by title or tome name (client-side).
+- Empty/loading/error states are handled inline.
+- `onSelect` is still exposed as a prop for the eventual "resume this
+  session" hand-off, but `page.tsx` does not yet pass one — clicking a
+  row is a no-op for now.
+
+## SQLite timestamp gotcha
+
+`sessions.created_at` defaults to `datetime('now')`, which returns
+`YYYY-MM-DD HH:MM:SS` in UTC with no `Z` suffix. `Message.created_at`
+uses Python `datetime.utcnow().isoformat()` which *does* include a `T`.
+`formatTimestamp` normalises both forms before constructing a `Date`,
+so mixed records render correctly.
+
+## Why no quiz / flashcard / audio / report rows yet?
+
+The schema only persists chat sessions. Quiz and flashcard generations
+are stateless POSTs (`/api/generate/...`) — nothing is written to disk.
+Audio and report views still render sample fixtures. When any of those
+gain server-side persistence, extend `list_sessions` (or add sibling
+endpoints) and widen the `HistoryItem["type"]` union — the `ICONS` map
+already follows that shape.

--- a/docs/in-chat-command-routing.md
+++ b/docs/in-chat-command-routing.md
@@ -1,0 +1,74 @@
+# In-chat command routing
+
+The verb router used to live only in the command bar. Once the user was in
+the chat view, typing "make flashcards on attention" into the chat textarea
+went straight to `/api/chat` and came back as markdown describing flashcards,
+instead of switching to the flashcards view.
+
+This refactor lifts the verb-detection logic into a shared
+`detectView(text)` helper at the page level and exposes it to `ChatWidget`
+through an `onCommand` callback.
+
+## Behavior
+
+- `detectView(text)` returns one of the non-chat view states (or `null`).
+  Supported keyword groups:
+
+  | Keyword(s)                                                  | View         |
+  |-------------------------------------------------------------|--------------|
+  | `quiz`, whole-word `test` / `tests` / `testing`             | `quiz`       |
+  | `flashcard`, `flash card`                                   | `flashcards` |
+  | `audio`, `listen`, `podcast`                                | `audio`      |
+  | `report`, `study guide`, `summary`                          | `report`     |
+  | `history`                                                   | `history`    |
+  | `tome`, `collection`, `library`                             | `tomes`      |
+  | `knowledge`, `kb`, `docs`, `documents`, `knowledge base`, … | `knowledge`  |
+
+  Anything else falls through to chat.
+
+- `page.tsx` passes `handleChatCommand(text)` into `ChatWidget` as
+  `onCommand`. Inside `ChatWidget`, `handleSend` (and the `initialQuery`
+  effect) call `onCommand?.(text)` first — if it returns `true`, the chat
+  call is skipped and the page has already switched view.
+
+- For `quiz` / `flashcards`, the matching prompt is also stored as
+  `generationPrompt` so `FlashcardsView` / `QuizView` can pass it as the
+  `topic` to the generation endpoints. See
+  [generation-endpoints.md](./generation-endpoints.md).
+
+## Agent self-awareness of routing
+
+The frontend intercepts and routes verb-containing prompts *before* they
+reach the chat endpoint, so the chat model never actually executes a
+"make flashcards" instruction itself. But users still ask "what can you
+do?" inside chat, and the model needs to answer correctly.
+
+To handle that, `SYSTEM_PROMPT` in `backend/api/chat.py` includes an
+"App capabilities you should know about" section that lists every routing
+keyword and the view it opens, plus the upload-modal flow for getting
+documents into the knowledge base. The prompt also tells the model:
+
+- *Do not* try to render quizzes, flashcards, audio, etc., as markdown —
+  point the user at the keyword and let the app open the real view.
+- If the user invokes a routed feature inside chat, the app switches views
+  before the model's reply is needed, so the model can safely no-op.
+
+Keep this section in sync with `detectView` in `frontend/src/app/page.tsx`
+whenever a new keyword group is added — they are the single source of
+truth pair for in-app capabilities.
+
+## Why "test" uses a word boundary
+
+`test` appears mid-word a lot ("testimony", "latest"). The detector uses
+`/\btest(s|ing)?\b/` so only `test`, `tests`, or `testing` as standalone
+words trigger the quiz view.
+
+## Files touched
+
+- `frontend/src/app/page.tsx` — extracted `detectView`, added
+  `handleChatCommand`, threaded `generationPrompt` state.
+- `frontend/src/components/ChatWidget.tsx` — added `onCommand` prop and
+  short-circuit in `handleSend` / initial-query effect.
+- `backend/api/chat.py` — extended `SYSTEM_PROMPT` with the
+  "App capabilities you should know about" section so the agent can
+  describe its own routed features when asked.

--- a/docs/knowledge-base-ui.md
+++ b/docs/knowledge-base-ui.md
@@ -1,0 +1,74 @@
+# Knowledge base UI
+
+Two related additions: a way to add documents *into* the knowledge base, and
+a way to view what's already in it.
+
+## 1. Upload modal
+
+A circular icon button now sits to the right of the command-bar pill.
+Clicking it opens `UploadModal`, which lets the user:
+
+- Paste raw text into a textarea.
+- Drag-and-drop or "Choose file" a plain-text file. Supported extensions:
+  `.txt`, `.md`, `.markdown`, `.rst`, `.csv`, `.json`, `.log`, plus any
+  file with a `text/*` MIME type.
+- Edit the auto-derived title.
+- Submit, which calls `ingestDocument()` → `POST /api/knowledge/ingest`.
+
+The backend deduplicates by SHA-256 of the content, so re-uploading the
+same file is safe and surfaces "already in knowledge base" instead of
+double-indexing.
+
+### Caveats
+
+- **Binary formats (PDF, DOCX, images) are not supported through this UI**.
+  The ingest endpoint takes `content: string`. The backend already has
+  `services/pdf.py::PDFService.extract_text` used by the arXiv flow — if you
+  want PDF upload from the UI, the cleanest path is a new `multipart/form-data`
+  endpoint that calls `PDFService.extract_text` and then forwards into the
+  existing ingest pipeline.
+- The modal accepts an optional `tomeId` so the new document can be linked
+  to the active tome. The `CommandBar` plumbs the prop through but there is
+  no "active tome" state at the page level yet, so uploads currently go to
+  the global knowledge base.
+
+## 2. Knowledge-base viewer
+
+Typing any of `knowledge`, `kb`, `docs`, `documents`, `knowledge base`,
+`view/show/list documents` into the command bar switches the view to
+`KnowledgeBaseWidget`. Two-pane layout:
+
+- **Left**: scrollable list of every ingested document (title, doc_type,
+  source, ingest time). Calls `listDocuments({ limit: 200 })`.
+- **Right**: detail panel for the selected document. Calls
+  `getDocument(id)` and shows source, type, chunk count, content hash,
+  linked tomes, and a 200-char content preview.
+- **Header actions**: Refresh button. Per-document Delete button in the
+  detail panel (`deleteDocument(id)`).
+
+The content preview comes from the backend's
+`GET /api/knowledge/documents/{id}` response, which returns
+`chunks[0].content[:200]` (`backend/api/knowledge.py`). If you want full
+chunk text in the UI, extend that endpoint to return all chunk content.
+
+## Files touched
+
+### Backend
+
+No changes — these UI flows reuse existing endpoints:
+- `POST /api/knowledge/ingest`
+- `GET  /api/knowledge/documents`
+- `GET  /api/knowledge/documents/{id}`
+- `DELETE /api/knowledge/documents/{id}`
+
+### Frontend
+
+- `frontend/src/components/UploadModal.tsx` (new) — paste / drop / choose-file
+  modal that POSTs to `/api/knowledge/ingest`.
+- `frontend/src/components/CommandBar.tsx` — adds the round upload button to
+  the right of the pill and renders `UploadModal`.
+- `frontend/src/components/KnowledgeBaseWidget.tsx` (new) — list + detail view.
+- `frontend/src/lib/sage-api.ts` — added `listDocuments`, `getDocument`,
+  `deleteDocument`, and matching types.
+- `frontend/src/app/page.tsx` — registered the `"knowledge"` view-state and
+  command-verb routing.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "agentation": "^3.0.2",
         "axios": "^1.8.4",
         "eslint": "^9",
         "eslint-config-next": "15.2.3",
@@ -68,9 +69,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -89,9 +90,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -149,34 +150,37 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.1.0.tgz",
-      "integrity": "sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -187,20 +191,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
-      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -211,19 +215,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.22.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
-      "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -231,13 +238,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -310,10 +317,20 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -329,13 +346,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -351,13 +368,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -371,9 +388,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -387,9 +404,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -403,9 +420,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -418,10 +435,42 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
@@ -435,9 +484,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -451,9 +500,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -467,9 +516,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -483,9 +532,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -501,13 +550,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -523,13 +572,57 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
@@ -545,13 +638,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -567,13 +660,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -589,13 +682,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -611,20 +704,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -633,10 +726,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -653,9 +765,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -685,9 +797,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
-      "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -701,9 +813,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
-      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -717,9 +829,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
-      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -733,9 +845,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
-      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -749,9 +861,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
-      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -765,9 +877,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
-      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -781,9 +893,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
-      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -797,9 +909,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
-      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -813,9 +925,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -889,12 +1001,6 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1391,18 +1497,18 @@
       }
     },
     "node_modules/@tauri-apps/plugin-shell": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.2.0.tgz",
-      "integrity": "sha512-iC3Ic1hLmasoboG7BO+7p+AriSoqAwKrIk+Hpk+S/bjTQdXqbl2GbdclghI4gM32X0bls7xHzIFqhRdrlvJeaA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tauri-apps/plugin-shell/node_modules/@tauri-apps/api": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.4.0.tgz",
-      "integrity": "sha512-F1zXTsmwcCp+ocg6fbzD/YL0OHeSG1eynCag1UNlX2tD5+dlXy7eRbTu9cAcscPjcR7Nix7by2wiv/+VfWUieg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1665,9 +1771,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1705,13 +1811,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1927,9 +2033,9 @@
       ]
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1949,10 +2055,29 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agentation": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/agentation/-/agentation-3.0.2.tgz",
+      "integrity": "sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==",
+      "dev": true,
+      "license": "PolyForm-Shield-1.0.0",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2208,15 +2333,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2268,17 +2393,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/call-bind": {
@@ -2447,25 +2561,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2478,19 +2578,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2720,9 +2809,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2991,33 +3080,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.22.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
-      "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
-        "@eslint/config-helpers": "^0.1.0",
-        "@eslint/core": "^0.12.0",
-        "@eslint/eslintrc": "^3.3.0",
-        "@eslint/js": "9.22.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3029,7 +3117,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3323,9 +3411,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3340,9 +3428,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3353,15 +3441,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3552,16 +3640,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -3596,15 +3684,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4229,13 +4318,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/is-async-function": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
@@ -4690,9 +4772,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5390,9 +5472,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6082,9 +6164,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6151,15 +6233,13 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.4.tgz",
-      "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.4",
-        "@swc/counter": "0.1.3",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
-        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -6171,19 +6251,19 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.4",
-        "@next/swc-darwin-x64": "15.2.4",
-        "@next/swc-linux-arm64-gnu": "15.2.4",
-        "@next/swc-linux-arm64-musl": "15.2.4",
-        "@next/swc-linux-x64-gnu": "15.2.4",
-        "@next/swc-linux-x64-musl": "15.2.4",
-        "@next/swc-win32-arm64-msvc": "15.2.4",
-        "@next/swc-win32-x64-msvc": "15.2.4",
-        "sharp": "^0.33.5"
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.51.1",
         "babel-plugin-react-compiler": "*",
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -6509,9 +6589,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6532,9 +6612,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -6552,7 +6632,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6607,11 +6687,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7027,9 +7110,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -7089,16 +7172,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -7107,25 +7190,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -7227,16 +7315,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7262,14 +7340,6 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -7551,9 +7621,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "agentation": "^3.0.2",
     "axios": "^1.8.4",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import AgentationDev from "@/components/AgentationDev";
 
 export const metadata = {
   title: "Sage",
@@ -20,6 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen w-full bg-transparent overflow-hidden font-body text-on-surface antialiased">
         {children}
+        <AgentationDev />
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,37 +3,69 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import CommandBar from "@/components/CommandBar";
-import QuizWidget, { SAMPLE_QUESTIONS } from "@/components/QuizWidget";
-import FlashcardWidget, { SAMPLE_FLASHCARDS } from "@/components/FlashcardWidget";
-import AudioPlayerWidget, { SAMPLE_TRACK } from "@/components/AudioPlayerWidget";
-import ReportViewWidget, { SAMPLE_REPORT } from "@/components/ReportViewWidget";
+import FlashcardsView from "@/components/FlashcardsView";
+import QuizView from "@/components/QuizView";
+import AudioView from "@/components/AudioView";
+import ReportView from "@/components/ReportView";
 import HistoryPanel from "@/components/HistoryPanel";
 import TomeSelector from "@/components/TomeSelector";
 import ChatWidget from "@/components/ChatWidget";
+import KnowledgeBaseWidget from "@/components/KnowledgeBaseWidget";
 
-type ViewState = "idle" | "quiz" | "flashcards" | "audio" | "report" | "history" | "tomes" | "chat";
+type ViewState = "idle" | "quiz" | "flashcards" | "audio" | "report" | "history" | "tomes" | "chat" | "knowledge";
+
+/** Map a free-text prompt to a non-chat view, or null if it should go to chat. */
+function detectView(text: string): Exclude<ViewState, "chat" | "idle"> | null {
+  const lower = text.toLowerCase().trim();
+  if (lower.includes("quiz") || /\btest(s|ing)?\b/.test(lower)) return "quiz";
+  if (lower.includes("flashcard") || lower.includes("flash card")) return "flashcards";
+  if (lower.includes("audio") || lower.includes("listen") || lower.includes("podcast")) return "audio";
+  if (lower.includes("report") || lower.includes("study guide") || lower.includes("summary")) return "report";
+  if (lower.includes("history")) return "history";
+  if (lower.includes("tome") || lower.includes("collection") || lower.includes("library")) return "tomes";
+  if (
+    lower === "knowledge" ||
+    lower === "kb" ||
+    lower === "docs" ||
+    lower === "documents" ||
+    lower.includes("knowledge base") ||
+    lower.includes("view documents") ||
+    lower.includes("show documents") ||
+    lower.includes("list documents")
+  ) {
+    return "knowledge";
+  }
+  return null;
+}
 
 export default function Home() {
   const [viewState, setViewState] = useState<ViewState>("idle");
+  const [chatQuery, setChatQuery] = useState<string>("");
+
+  const [generationPrompt, setGenerationPrompt] = useState<string>("");
 
   const handleSubmit = (text: string) => {
-    const lower = text.toLowerCase().trim();
-
-    if (lower.includes("quiz")) {
-      setViewState("quiz");
-    } else if (lower.includes("flashcard") || lower.includes("flash card")) {
-      setViewState("flashcards");
-    } else if (lower.includes("audio") || lower.includes("listen") || lower.includes("podcast")) {
-      setViewState("audio");
-    } else if (lower.includes("report") || lower.includes("study guide") || lower.includes("summary")) {
-      setViewState("report");
-    } else if (lower.includes("history")) {
-      setViewState("history");
-    } else if (lower.includes("tome") || lower.includes("collection") || lower.includes("library")) {
-      setViewState("tomes");
+    const route = detectView(text);
+    if (route) {
+      if (route === "quiz" || route === "flashcards" || route === "audio" || route === "report") {
+        setGenerationPrompt(text);
+      }
+      setViewState(route);
     } else {
+      setChatQuery(text);
       setViewState("chat");
     }
+  };
+
+  /** Called from inside ChatWidget. Returns true if it routed away from chat. */
+  const handleChatCommand = (text: string): boolean => {
+    const route = detectView(text);
+    if (!route) return false;
+    if (route === "quiz" || route === "flashcards" || route === "audio" || route === "report") {
+      setGenerationPrompt(text);
+    }
+    setViewState(route);
+    return true;
   };
 
   const handleBack = () => {
@@ -48,78 +80,126 @@ export default function Home() {
 
   const cardTransition = { duration: 0.28, ease: [0.25, 0.46, 0.45, 0.94] };
 
+  const layoutTransition = { duration: 0.45, ease: [0.25, 0.46, 0.45, 0.94] as const };
+
   return (
-    <main className="relative w-full min-h-screen flex flex-col items-center pt-24 pb-12 gap-5">
+    <main className="relative w-full min-h-screen flex flex-col items-center">
       {/* Ambient glow */}
       <div className="ambient-glow" />
 
-      {/* Command bar — always visible, shifts up when content appears */}
+      {/* Top spacer: shares space with bottom when idle so the command bar sits on the vertical midline */}
       <div
-        className={`relative z-10 transition-all duration-500 ease-out ${
-          viewState !== "idle" ? "pt-0" : "pt-8"
-        }`}
+        className={`w-full shrink-0 transition-all duration-500 ease-out ${viewState === "idle" ? "flex-1 min-h-0 basis-0" : "h-24 flex-none"
+          }`}
+        aria-hidden
+      />
+
+      <motion.div
+        layout
+        transition={{ layout: layoutTransition }}
+        className={`relative z-10 w-full flex justify-center transition-[padding] duration-500 ease-out ${viewState === "idle" ? "pb-0" : "pb-8"
+          }`}
       >
-        <CommandBar onSubmit={handleSubmit} />
+        <div className="flex w-full max-w-[660px] flex-col items-center gap-8 px-6">
+          <header className="flex w-full flex-col items-center px-2 text-center">
+            <p className="m-0 text-center font-headline text-2xl font-semibold leading-tight tracking-[0.28em] text-on-surface sm:text-3xl sm:tracking-[0.26em]">
+              SAGE
+            </p>
+          </header>
+          <CommandBar
+            onSubmit={handleSubmit}
+            isKnowledgeBaseOpen={viewState === "knowledge"}
+            onKnowledgeBaseToggle={() =>
+              setViewState((s) => (s === "knowledge" ? "idle" : "knowledge"))
+            }
+          />
+          {viewState === "idle" && (
+            <p className="m-0 max-w-md px-2 text-center text-xs leading-relaxed text-on-surface-variant">
+              This project is based on{" "}
+              <a
+                href="https://arxiv.org/abs/2603.15255"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline-offset-2 hover:underline"
+              >
+                SAGE: Multi-Agent Self-Evolution for LLM Reasoning
+              </a>{" "}
+              (Peng et al., arXiv:2603.15255).
+            </p>
+          )}
+        </div>
+      </motion.div>
+
+      {/* Content area — second flex-1 when idle balances the top spacer for vertical centering */}
+      <div
+        className="flex flex-col items-center gap-5 w-full pb-12 shrink-0 flex-1 min-h-0 basis-0"
+      >
+        <AnimatePresence mode="wait">
+          {viewState === "quiz" && (
+            <motion.div key="quiz" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <QuizView prompt={generationPrompt} />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "flashcards" && (
+            <motion.div key="flashcards" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <FlashcardsView prompt={generationPrompt} />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "audio" && (
+            <motion.div key="audio" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <AudioView prompt={generationPrompt} />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "report" && (
+            <motion.div key="report" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <ReportView prompt={generationPrompt} />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "history" && (
+            <motion.div key="history" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <HistoryPanel />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "tomes" && (
+            <motion.div key="tomes" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <TomeSelector />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "knowledge" && (
+            <motion.div key="knowledge" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <KnowledgeBaseWidget />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+
+          {viewState === "chat" && (
+            <motion.div key="chat" {...cardVariants} transition={cardTransition}
+              className="relative z-10 w-full flex flex-col items-center gap-4">
+              <ChatWidget initialQuery={chatQuery} onCommand={handleChatCommand} />
+              <BackButton onClick={handleBack} />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
-
-      {/* Content area */}
-      <AnimatePresence mode="wait">
-        {viewState === "quiz" && (
-          <motion.div key="quiz" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <QuizWidget title="Transformers Quiz" questions={SAMPLE_QUESTIONS} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "flashcards" && (
-          <motion.div key="flashcards" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <FlashcardWidget title="Transformer Concepts" cards={SAMPLE_FLASHCARDS} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "audio" && (
-          <motion.div key="audio" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <AudioPlayerWidget track={SAMPLE_TRACK} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "report" && (
-          <motion.div key="report" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <ReportViewWidget report={SAMPLE_REPORT} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "history" && (
-          <motion.div key="history" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <HistoryPanel />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "tomes" && (
-          <motion.div key="tomes" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <TomeSelector />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "chat" && (
-          <motion.div key="chat" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <ChatWidget />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-      </AnimatePresence>
     </main>
   );
 }

--- a/frontend/src/components/AgentationDev.tsx
+++ b/frontend/src/components/AgentationDev.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { Agentation } from "agentation";
+
+export default function AgentationDev() {
+  if (process.env.NODE_ENV !== "development") return null;
+  return <Agentation />;
+}

--- a/frontend/src/components/AudioPlayerWidget.tsx
+++ b/frontend/src/components/AudioPlayerWidget.tsx
@@ -21,6 +21,13 @@ interface AudioTrack {
 
 interface AudioPlayerWidgetProps {
   track: AudioTrack;
+  /** Direct URL to a synthesized audio file (e.g. OpenAI TTS MP3). When
+   *  provided, a real <audio> element drives playback. When null/undefined
+   *  the widget falls back to browser SpeechSynthesis. */
+  audioUrl?: string | null;
+  /** Full narration script — used for SpeechSynthesis fallback when no
+   *  audioUrl is available. If absent the concatenated transcript is used. */
+  script?: string;
 }
 
 // --- Sample data for prototyping ---
@@ -92,35 +99,68 @@ function formatTime(seconds: number): string {
 
 // --- Component ---
 
-export default function AudioPlayerWidget({ track }: AudioPlayerWidgetProps) {
+export default function AudioPlayerWidget({ track, audioUrl, script }: AudioPlayerWidgetProps) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [showTranscript, setShowTranscript] = useState(true);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const transcriptRef = useRef<HTMLDivElement>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const speechRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const speechStartRef = useRef<number>(0);
+  const speechBaseTimeRef = useRef<number>(0);
 
-  // Simulate playback with a timer
+  // --- Mode A: real <audio> element (server-side TTS available) ---
   useEffect(() => {
+    if (!audioUrl) return;
+    const el = audioRef.current;
+    if (!el) return;
+    const onTime = () => setCurrentTime(el.currentTime);
+    const onEnded = () => {
+      setIsPlaying(false);
+      setCurrentTime(el.duration || track.duration);
+    };
+    el.addEventListener("timeupdate", onTime);
+    el.addEventListener("ended", onEnded);
+    return () => {
+      el.removeEventListener("timeupdate", onTime);
+      el.removeEventListener("ended", onEnded);
+    };
+  }, [audioUrl, track.duration]);
+
+  // --- Mode B: SpeechSynthesis fallback. Drive a timer for transcript
+  //     highlighting since the browser API doesn't expose word-level timing. ---
+  useEffect(() => {
+    if (audioUrl) return; // Mode A drives currentTime directly
     if (isPlaying) {
+      speechStartRef.current = performance.now();
       intervalRef.current = setInterval(() => {
-        setCurrentTime((prev) => {
-          if (prev >= track.duration) {
-            setIsPlaying(false);
-            return track.duration;
-          }
-          return prev + 0.1;
-        });
+        const elapsed = (performance.now() - speechStartRef.current) / 1000;
+        const t = speechBaseTimeRef.current + elapsed;
+        if (t >= track.duration) {
+          setCurrentTime(track.duration);
+          setIsPlaying(false);
+        } else {
+          setCurrentTime(t);
+        }
       }, 100);
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
     }
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [isPlaying, track.duration]);
+  }, [isPlaying, audioUrl, track.duration]);
+
+  // Cancel any in-flight speech if the widget unmounts or the track changes.
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined" && "speechSynthesis" in window) {
+        window.speechSynthesis.cancel();
+      }
+    };
+  }, [track.id]);
 
   // Auto-scroll transcript to active segment
   useEffect(() => {
@@ -133,29 +173,102 @@ export default function AudioPlayerWidget({ track }: AudioPlayerWidgetProps) {
     }
   }, [currentTime, showTranscript]);
 
+  const speechAvailable =
+    typeof window !== "undefined" && "speechSynthesis" in window;
+
+  const speakFromTime = useCallback(
+    (fromTime: number) => {
+      if (!speechAvailable) return;
+      const synth = window.speechSynthesis;
+      synth.cancel();
+
+      // Build the utterance from the segment at fromTime onwards so the
+      // audio you hear lines up with the highlighted transcript.
+      const remaining = track.transcript
+        .filter((s) => s.endTime > fromTime)
+        .map((s) => s.text)
+        .join(" ");
+      const text = remaining || script || track.transcript.map((s) => s.text).join(" ");
+      if (!text.trim()) return;
+
+      const utter = new SpeechSynthesisUtterance(text);
+      utter.rate = 1.0;
+      utter.onend = () => {
+        if (speechRef.current === utter) {
+          setIsPlaying(false);
+          setCurrentTime(track.duration);
+        }
+      };
+      speechRef.current = utter;
+      speechBaseTimeRef.current = fromTime;
+      speechStartRef.current = performance.now();
+      synth.speak(utter);
+    },
+    [speechAvailable, track.transcript, track.duration, script],
+  );
+
   const handlePlayPause = useCallback(() => {
-    if (currentTime >= track.duration) {
-      setCurrentTime(0);
+    if (audioUrl && audioRef.current) {
+      const el = audioRef.current;
+      if (currentTime >= track.duration) {
+        el.currentTime = 0;
+        setCurrentTime(0);
+      }
+      if (el.paused) {
+        void el.play();
+        setIsPlaying(true);
+      } else {
+        el.pause();
+        setIsPlaying(false);
+      }
+      return;
     }
-    setIsPlaying((p) => !p);
-  }, [currentTime, track.duration]);
+
+    // SpeechSynthesis path
+    if (!speechAvailable) return;
+    const synth = window.speechSynthesis;
+    if (isPlaying) {
+      synth.cancel();
+      setIsPlaying(false);
+      return;
+    }
+    if (currentTime >= track.duration) setCurrentTime(0);
+    speakFromTime(currentTime >= track.duration ? 0 : currentTime);
+    setIsPlaying(true);
+  }, [audioUrl, currentTime, track.duration, isPlaying, speechAvailable, speakFromTime]);
+
+  const seekTo = useCallback(
+    (t: number) => {
+      const clamped = Math.max(0, Math.min(track.duration, t));
+      setCurrentTime(clamped);
+      if (audioUrl && audioRef.current) {
+        audioRef.current.currentTime = clamped;
+        return;
+      }
+      // SpeechSynthesis can't truly seek — restart from the new spot if playing.
+      if (isPlaying && speechAvailable) {
+        speakFromTime(clamped);
+      }
+    },
+    [audioUrl, track.duration, isPlaying, speechAvailable, speakFromTime],
+  );
 
   const handleSeek = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const rect = e.currentTarget.getBoundingClientRect();
       const pct = (e.clientX - rect.left) / rect.width;
-      setCurrentTime(Math.max(0, Math.min(track.duration, pct * track.duration)));
+      seekTo(pct * track.duration);
     },
-    [track.duration]
+    [track.duration, seekTo],
   );
 
   const handlePrev = useCallback(() => {
-    setCurrentTime((t) => Math.max(0, t - 15));
-  }, []);
+    seekTo(currentTime - 15);
+  }, [seekTo, currentTime]);
 
   const handleNext = useCallback(() => {
-    setCurrentTime((t) => Math.min(track.duration, t + 15));
-  }, [track.duration]);
+    seekTo(currentTime + 15);
+  }, [seekTo, currentTime]);
 
   const progress = track.duration > 0 ? (currentTime / track.duration) * 100 : 0;
 
@@ -165,6 +278,14 @@ export default function AudioPlayerWidget({ track }: AudioPlayerWidgetProps) {
 
   return (
     <div className="w-full max-w-[640px] px-4">
+      {audioUrl && (
+        <audio
+          ref={audioRef}
+          src={audioUrl}
+          preload="auto"
+          className="hidden"
+        />
+      )}
       <div
         className="bg-surface/80 backdrop-blur-[32px] border border-outline-variant/15
                    rounded-2xl p-6
@@ -312,15 +433,29 @@ export default function AudioPlayerWidget({ track }: AudioPlayerWidgetProps) {
               {track.voice}
             </span>
           </div>
-          <button
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-label-sm
-                       border border-outline-variant/15 text-on-surface-variant
-                       hover:border-outline-variant/30 hover:text-on-surface
-                       transition-all duration-150 uppercase tracking-[0.05em]"
-          >
-            <span className="material-symbols-outlined text-sm">download</span>
-            Download
-          </button>
+          {audioUrl ? (
+            <a
+              href={audioUrl}
+              download={`${track.id || "sage-audio"}.mp3`}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-label-sm
+                         border border-outline-variant/15 text-on-surface-variant
+                         hover:border-outline-variant/30 hover:text-on-surface
+                         transition-all duration-150 uppercase tracking-[0.05em]"
+            >
+              <span className="material-symbols-outlined text-sm">download</span>
+              Download
+            </a>
+          ) : (
+            <span
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-label-sm
+                         border border-outline-variant/10 text-on-surface-variant/50
+                         uppercase tracking-[0.05em] cursor-not-allowed"
+              title="Server-side TTS not configured — playback uses your browser's voice."
+            >
+              <span className="material-symbols-outlined text-sm">graphic_eq</span>
+              Browser TTS
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/AudioView.tsx
+++ b/frontend/src/components/AudioView.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import AudioPlayerWidget from "./AudioPlayerWidget";
+import {
+  generateAudio,
+  resolveAudioUrl,
+  type AudioGeneration,
+  type GeneratedSource,
+} from "@/lib/sage-api";
+
+interface AudioViewProps {
+  prompt: string;
+  tomeId?: string;
+  voice?: string;
+}
+
+export default function AudioView({ prompt, tomeId, voice }: AudioViewProps) {
+  const [data, setData] = useState<AudioGeneration | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setData(null);
+    setError(null);
+    generateAudio({ topic: prompt || undefined, tomeId, voice })
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [prompt, tomeId, voice, reloadKey]);
+
+  if (error) {
+    return (
+      <StatusCard
+        icon="error"
+        title="Couldn't generate audio"
+        detail={error}
+        onRetry={() => setReloadKey((k) => k + 1)}
+      />
+    );
+  }
+
+  if (!data) {
+    return (
+      <StatusCard
+        icon="hourglass_top"
+        title="Generating narration…"
+        detail="Searching your knowledge base and writing the script. If server-side TTS isn't configured, playback will use your browser's voice."
+      />
+    );
+  }
+
+  const track = {
+    id: data.id,
+    title: data.title,
+    voice: data.voice,
+    duration: data.duration,
+    transcript: data.segments,
+  };
+  const audioUrl = data.audio_url ? resolveAudioUrl(data.audio_url) : null;
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <AudioPlayerWidget track={track} audioUrl={audioUrl} script={data.script} />
+      {data.sources.length > 0 && <SourcesFooter sources={data.sources} />}
+    </div>
+  );
+}
+
+function StatusCard({
+  icon, title, detail, onRetry,
+}: { icon: string; title: string; detail?: string; onRetry?: () => void }) {
+  return (
+    <div className="w-full max-w-[640px] px-4">
+      <div className="bg-surface/80 backdrop-blur-[32px] border border-outline-variant/15 rounded-2xl px-6 py-8
+                      shadow-[0_8px_32px_rgba(0,0,0,0.4)] flex flex-col items-center gap-2 text-center">
+        <span className="material-symbols-outlined text-primary text-3xl">{icon}</span>
+        <div className="text-title-md text-on-surface">{title}</div>
+        {detail && <div className="text-body-md text-on-surface-variant max-w-[480px]">{detail}</div>}
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 px-3 py-1 rounded-full text-label-md border border-outline-variant/20
+                       text-on-surface-variant hover:border-primary/40 hover:text-on-surface transition-colors"
+          >
+            Try again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourcesFooter({ sources }: { sources: GeneratedSource[] }) {
+  const unique = Array.from(new Map(sources.map((s) => [s.document_id, s])).values());
+  return (
+    <div className="w-full max-w-[640px] px-4 text-label-sm text-on-surface-variant flex flex-wrap gap-1.5 justify-center">
+      <span className="text-on-surface-variant/60">Grounded in:</span>
+      {unique.map((s) => (
+        <span
+          key={s.document_id}
+          className="bg-surface-container-low border border-outline-variant/10 rounded-full px-2.5 py-0.5"
+        >
+          {s.document_title}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ChatWidget.tsx
+++ b/frontend/src/components/ChatWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { sendChat, getRuntimeConfig } from "@/lib/sage-api";
 
 // --- Types ---
 
@@ -14,8 +15,14 @@ interface ChatMessage {
 interface ChatWidgetProps {
   tomeName?: string;
   providerName?: string;
+  tomeId?: string;
+  provider?: string;
+  model?: string;
   messages?: ChatMessage[];
+  initialQuery?: string;
   onSend?: (message: string) => void;
+  /** If returns true, ChatWidget skips backend chat — parent has routed elsewhere. */
+  onCommand?: (message: string) => boolean;
   isLoading?: boolean;
 }
 
@@ -52,48 +59,103 @@ export const SAMPLE_MESSAGES: ChatMessage[] = [
 
 export default function ChatWidget({
   tomeName = "Deep Learning Foundations",
-  providerName = "GPT-4o",
-  messages: initialMessages = SAMPLE_MESSAGES,
+  providerName,
+  tomeId,
+  provider,
+  model,
+  messages: initialMessages,
+  initialQuery,
   onSend,
-  isLoading = false,
+  onCommand,
+  isLoading: isLoadingProp,
 }: ChatWidgetProps) {
-  const [messages, setMessages] = useState(initialMessages);
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages ?? []);
   const [input, setInput] = useState("");
+  const [internalLoading, setInternalLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | undefined>(undefined);
+  const [resolvedModel, setResolvedModel] = useState<string | undefined>(model);
+
+  useEffect(() => {
+    if (providerName || model) return;
+    let cancelled = false;
+    getRuntimeConfig()
+      .then((cfg) => {
+        if (!cancelled) setResolvedModel(cfg.model || cfg.provider);
+      })
+      .catch(() => {
+        if (!cancelled) setResolvedModel("offline");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [providerName, model]);
+
+  const modelLabel = providerName ?? resolvedModel ?? "…";
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const initialSentRef = useRef(false);
+
+  const isLoading = isLoadingProp ?? internalLoading;
 
   // Auto-scroll to bottom
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [messages]);
+  }, [messages, isLoading]);
+
+  const sendToBackend = useCallback(
+    async (text: string) => {
+      const userMsg: ChatMessage = {
+        id: `u-${Date.now()}`,
+        role: "user",
+        content: text,
+        timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+      onSend?.(text);
+      setInternalLoading(true);
+
+      try {
+        const res = await sendChat(text, { sessionId, tomeId, provider, model });
+        if (!sessionId) setSessionId(res.session_id);
+        const assistantMsg: ChatMessage = {
+          id: `a-${Date.now()}`,
+          role: "assistant",
+          content: res.response,
+          timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      } catch (err) {
+        const errorMsg: ChatMessage = {
+          id: `e-${Date.now()}`,
+          role: "assistant",
+          content: `**Error reaching backend:** ${err instanceof Error ? err.message : String(err)}`,
+          timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+        };
+        setMessages((prev) => [...prev, errorMsg]);
+      } finally {
+        setInternalLoading(false);
+      }
+    },
+    [sessionId, tomeId, provider, model, onSend],
+  );
+
+  // Auto-send initial query (e.g. from CommandBar)
+  useEffect(() => {
+    if (initialQuery && !initialSentRef.current) {
+      initialSentRef.current = true;
+      if (onCommand?.(initialQuery)) return;
+      void sendToBackend(initialQuery);
+    }
+  }, [initialQuery, sendToBackend, onCommand]);
 
   const handleSend = () => {
     const text = input.trim();
     if (!text || isLoading) return;
-
-    const userMsg: ChatMessage = {
-      id: `u-${Date.now()}`,
-      role: "user",
-      content: text,
-      timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
-    };
-
-    setMessages((prev) => [...prev, userMsg]);
     setInput("");
-    onSend?.(text);
-
-    // Simulate assistant response for prototyping
-    setTimeout(() => {
-      const assistantMsg: ChatMessage = {
-        id: `a-${Date.now()}`,
-        role: "assistant",
-        content: `I received your message: "${text}". In the real app, the agent would process this using the ${tomeName} tome and ${providerName}.`,
-        timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
-      };
-      setMessages((prev) => [...prev, assistantMsg]);
-    }, 1500);
+    if (onCommand?.(text)) return;
+    void sendToBackend(text);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -123,8 +185,7 @@ export default function ChatWidget({
               <span className="text-label-sm text-on-surface-variant truncate max-w-[140px]">{tomeName}</span>
             </div>
             <div className="flex items-center gap-1 bg-surface-container-high rounded-full px-2.5 py-1 border border-outline-variant/10">
-              <span className="text-label-sm text-primary leading-none">⚡</span>
-              <span className="text-label-sm text-on-surface-variant uppercase leading-none">{providerName}</span>
+              <span className="text-label-sm text-on-surface-variant uppercase leading-none">{modelLabel}</span>
             </div>
           </div>
         </div>
@@ -134,11 +195,10 @@ export default function ChatWidget({
           {messages.map((msg) => (
             <div key={msg.id} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
               <div
-                className={`max-w-[85%] rounded-2xl px-4 py-3 ${
-                  msg.role === "user"
+                className={`max-w-[85%] rounded-2xl px-4 py-3 ${msg.role === "user"
                     ? "bg-primary/15 border border-primary/20 text-on-surface"
                     : "bg-surface-container-low border border-outline-variant/10 text-on-surface-variant"
-                }`}
+                  }`}
               >
                 <div className="text-body-md leading-relaxed whitespace-pre-wrap">{msg.content}</div>
                 <div className={`text-label-sm mt-1.5 ${msg.role === "user" ? "text-primary/50" : "text-on-surface-variant/40"}`}>

--- a/frontend/src/components/CommandBar.tsx
+++ b/frontend/src/components/CommandBar.tsx
@@ -1,18 +1,41 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { getRuntimeConfig } from "@/lib/sage-api";
 
 interface CommandBarProps {
   onSubmit: (response: string) => void;
+  /** When true, the side button shows close and returns to idle on click. */
+  isKnowledgeBaseOpen?: boolean;
+  onKnowledgeBaseToggle?: () => void;
 }
 
-export default function CommandBar({ onSubmit }: CommandBarProps) {
+export default function CommandBar({
+  onSubmit,
+  isKnowledgeBaseOpen = false,
+  onKnowledgeBaseToggle,
+}: CommandBarProps) {
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [modelLabel, setModelLabel] = useState("…");
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getRuntimeConfig()
+      .then((cfg) => {
+        if (!cancelled) setModelLabel(cfg.model || cfg.provider || "unknown");
+      })
+      .catch(() => {
+        if (!cancelled) setModelLabel("offline");
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -27,9 +50,9 @@ export default function CommandBar({ onSubmit }: CommandBarProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="relative z-10 w-full max-w-[600px] px-4">
+    <form onSubmit={handleSubmit} className="relative z-10 w-full max-w-[660px] px-4 flex items-center gap-2">
       <div
-        className="h-12 w-full bg-surface/80 backdrop-blur-[32px] rounded-full border border-outline-variant/15
+        className="h-12 flex-1 bg-surface/80 backdrop-blur-[32px] rounded-full border border-outline-variant/15
                    flex items-center px-4
                    shadow-[0_8px_32px_rgba(0,0,0,0.4),0_0_60px_rgba(173,198,255,0.04)]
                    transition-all duration-300 hover:border-outline-variant/30
@@ -58,12 +81,33 @@ export default function CommandBar({ onSubmit }: CommandBarProps) {
 
         {/* Provider badge */}
         <div className="flex items-center gap-1 bg-surface-container-high rounded-full px-2.5 py-1 border border-outline-variant/10 flex-shrink-0 cursor-default hover:border-primary/40 transition-colors">
-          <span className="text-label-sm text-primary leading-none">⚡</span>
           <span className="text-label-sm text-on-surface-variant font-medium uppercase leading-none mt-[1px]">
-            GPT-4o
+            {modelLabel}
           </span>
         </div>
       </div>
+
+      {/* Knowledge base: open (library) or close (X) when already open */}
+      <button
+        type="button"
+        onClick={() => onKnowledgeBaseToggle?.()}
+        title={
+          isKnowledgeBaseOpen
+            ? "Close knowledge base"
+            : "Browse and upload knowledge base documents"
+        }
+        aria-label={isKnowledgeBaseOpen ? "Close knowledge base" : "Open knowledge base"}
+        className="h-12 w-12 flex-shrink-0 rounded-full bg-surface/80 backdrop-blur-[32px]
+                   border border-outline-variant/15
+                   shadow-[0_8px_32px_rgba(0,0,0,0.4),0_0_60px_rgba(173,198,255,0.04)]
+                   flex items-center justify-center text-on-surface-variant
+                   hover:border-primary/40 hover:text-primary
+                   transition-all duration-300"
+      >
+        <span className="material-symbols-outlined text-xl" aria-hidden>
+          {isKnowledgeBaseOpen ? "close" : "library_add"}
+        </span>
+      </button>
     </form>
   );
 }

--- a/frontend/src/components/FlashcardsView.tsx
+++ b/frontend/src/components/FlashcardsView.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import FlashcardWidget from "./FlashcardWidget";
+import {
+  generateFlashcards,
+  type GeneratedFlashcard,
+  type GeneratedSource,
+} from "@/lib/sage-api";
+
+interface FlashcardsViewProps {
+  prompt: string;
+  tomeId?: string;
+  count?: number;
+}
+
+export default function FlashcardsView({ prompt, tomeId, count = 6 }: FlashcardsViewProps) {
+  const [cards, setCards] = useState<GeneratedFlashcard[] | null>(null);
+  const [sources, setSources] = useState<GeneratedSource[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCards(null);
+    setError(null);
+    setSources([]);
+    generateFlashcards({ topic: prompt || undefined, tomeId, count })
+      .then((res) => {
+        if (cancelled) return;
+        setCards(res.cards);
+        setSources(res.sources);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [prompt, tomeId, count, reloadKey]);
+
+  if (error) {
+    return (
+      <StatusCard
+        icon="error"
+        title="Couldn't generate flashcards"
+        detail={error}
+        onRetry={() => setReloadKey((k) => k + 1)}
+      />
+    );
+  }
+
+  if (!cards) {
+    return <StatusCard icon="hourglass_top" title="Generating flashcards…" detail="Searching your knowledge base and writing cards." />;
+  }
+
+  const title = prompt.trim() ? `Flashcards: ${prompt.trim()}` : "Flashcards";
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <FlashcardWidget title={title} cards={cards} />
+      {sources.length > 0 && <SourcesFooter sources={sources} />}
+    </div>
+  );
+}
+
+function StatusCard({
+  icon, title, detail, onRetry,
+}: { icon: string; title: string; detail?: string; onRetry?: () => void }) {
+  return (
+    <div className="w-full max-w-[640px] px-4">
+      <div className="bg-surface/80 backdrop-blur-[32px] border border-outline-variant/15 rounded-2xl px-6 py-8
+                      shadow-[0_8px_32px_rgba(0,0,0,0.4)] flex flex-col items-center gap-2 text-center">
+        <span className="material-symbols-outlined text-primary text-3xl">{icon}</span>
+        <div className="text-title-md text-on-surface">{title}</div>
+        {detail && <div className="text-body-md text-on-surface-variant max-w-[480px]">{detail}</div>}
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 px-3 py-1 rounded-full text-label-md border border-outline-variant/20
+                       text-on-surface-variant hover:border-primary/40 hover:text-on-surface transition-colors"
+          >
+            Try again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourcesFooter({ sources }: { sources: GeneratedSource[] }) {
+  const unique = Array.from(new Map(sources.map((s) => [s.document_id, s])).values());
+  return (
+    <div className="w-full max-w-[640px] px-4 text-label-sm text-on-surface-variant flex flex-wrap gap-1.5 justify-center">
+      <span className="text-on-surface-variant/60">Grounded in:</span>
+      {unique.map((s) => (
+        <span
+          key={s.document_id}
+          className="bg-surface-container-low border border-outline-variant/10 rounded-full px-2.5 py-0.5"
+        >
+          {s.document_title}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/HistoryPanel.tsx
+++ b/frontend/src/components/HistoryPanel.tsx
@@ -1,67 +1,138 @@
 "use client";
 
-import { useState } from "react";
-
-// --- Types ---
+import { useEffect, useMemo, useState } from "react";
+import { listChatSessions, type ChatSessionSummary } from "@/lib/sage-api";
 
 interface HistoryItem {
   id: string;
-  type: "chat" | "quiz" | "flashcard" | "audio" | "report";
+  type: "chat";
   title: string;
   timestamp: string;
+  rawTimestamp: string;
   tomeName?: string;
 }
 
 interface HistoryPanelProps {
-  items?: HistoryItem[];
   onSelect?: (item: HistoryItem) => void;
 }
 
-// --- Sample data ---
-
-const ICONS: Record<string, { icon: string; color: string }> = {
-  chat: { icon: "chat_bubble", color: "text-blue-400" },
-  quiz: { icon: "quiz", color: "text-emerald-400" },
-  flashcard: { icon: "style", color: "text-amber-400" },
-  audio: { icon: "headphones", color: "text-violet-400" },
-  report: { icon: "description", color: "text-rose-400" },
+const ICONS: Record<HistoryItem["type"], { icon: string; color: string; label: string }> = {
+  chat: { icon: "chat_bubble", color: "text-blue-400", label: "Chat" },
 };
 
-export const SAMPLE_HISTORY: HistoryItem[] = [
-  { id: "1", type: "report", title: "Attention Mechanisms", timestamp: "2:34 PM", tomeName: "Deep Learning Foundations" },
-  { id: "2", type: "quiz", title: "Transformer Quiz", timestamp: "1:15 PM", tomeName: "Deep Learning Foundations" },
-  { id: "3", type: "audio", title: "Audio: BERT Architecture", timestamp: "12:02 PM", tomeName: "NLP Papers" },
-  { id: "4", type: "chat", title: "Explain backpropagation", timestamp: "11:30 AM", tomeName: "Deep Learning Foundations" },
-  { id: "5", type: "flashcard", title: "GPT Architecture Cards", timestamp: "Yesterday", tomeName: "NLP Papers" },
-  { id: "6", type: "report", title: "RLHF Overview", timestamp: "Yesterday", tomeName: "Alignment Research" },
-  { id: "7", type: "quiz", title: "CNN Fundamentals", timestamp: "2 days ago", tomeName: "Computer Vision" },
-  { id: "8", type: "chat", title: "Compare Adam vs SGD", timestamp: "2 days ago", tomeName: "Deep Learning Foundations" },
-];
+function deriveTitle(session: ChatSessionSummary): string {
+  const raw = (session.first_user_message ?? "").trim();
+  if (!raw) return "(empty session)";
+  const firstLine = raw.split("\n", 1)[0]!;
+  return firstLine.length > 90 ? firstLine.slice(0, 87) + "…" : firstLine;
+}
 
-// --- Component ---
+/** Render a timestamp relative-ish: today → time, otherwise short date. */
+function formatTimestamp(iso: string): { display: string; bucket: string } {
+  if (!iso) return { display: "", bucket: "Older" };
+  // SQLite "datetime('now')" returns "YYYY-MM-DD HH:MM:SS" in UTC without a Z suffix.
+  // The Document.created_at default uses ISO format. Handle both.
+  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T") + "Z";
+  const d = new Date(normalized);
+  if (Number.isNaN(d.getTime())) return { display: iso, bucket: "Older" };
 
-export default function HistoryPanel({ items = SAMPLE_HISTORY, onSelect }: HistoryPanelProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [filterType, setFilterType] = useState<string | null>(null);
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+  const startOfWeek = new Date(startOfToday);
+  startOfWeek.setDate(startOfWeek.getDate() - 6);
 
-  const filtered = items.filter((item) => {
-    const matchesSearch = !searchQuery || item.title.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesType = !filterType || item.type === filterType;
-    return matchesSearch && matchesType;
-  });
-
-  // Group by time
-  const groups: { label: string; items: HistoryItem[] }[] = [];
-  let currentGroup: { label: string; items: HistoryItem[] } | null = null;
-
-  for (const item of filtered) {
-    const label = item.timestamp.includes("PM") || item.timestamp.includes("AM") ? "Today" : item.timestamp;
-    if (!currentGroup || currentGroup.label !== label) {
-      currentGroup = { label, items: [] };
-      groups.push(currentGroup);
-    }
-    currentGroup.items.push(item);
+  if (d >= startOfToday) {
+    return {
+      display: d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+      bucket: "Today",
+    };
   }
+  if (d >= startOfYesterday) {
+    return {
+      display: d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+      bucket: "Yesterday",
+    };
+  }
+  if (d >= startOfWeek) {
+    return {
+      display: d.toLocaleDateString([], { weekday: "short", hour: "numeric", minute: "2-digit" }),
+      bucket: "Earlier this week",
+    };
+  }
+  return {
+    display: d.toLocaleDateString([], { year: "numeric", month: "short", day: "numeric" }),
+    bucket: "Older",
+  };
+}
+
+export default function HistoryPanel({ onSelect }: HistoryPanelProps) {
+  const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    listChatSessions(200)
+      .then((data) => {
+        if (!cancelled) setSessions(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const items = useMemo<HistoryItem[]>(
+    () =>
+      sessions
+        // Skip sessions that never received a user message — they're noise.
+        .filter((s) => s.message_count > 0 && s.first_user_message)
+        .map((s) => {
+          const ts = formatTimestamp(s.last_message_at);
+          return {
+            id: s.id,
+            type: "chat" as const,
+            title: deriveTitle(s),
+            timestamp: ts.display,
+            rawTimestamp: s.last_message_at,
+            tomeName: s.tome_name ?? undefined,
+          };
+        }),
+    [sessions],
+  );
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (item) =>
+        item.title.toLowerCase().includes(q) ||
+        (item.tomeName ?? "").toLowerCase().includes(q),
+    );
+  }, [items, searchQuery]);
+
+  const groups = useMemo(() => {
+    const map = new Map<string, HistoryItem[]>();
+    for (const item of filtered) {
+      const bucket = formatTimestamp(item.rawTimestamp).bucket;
+      const list = map.get(bucket);
+      if (list) list.push(item);
+      else map.set(bucket, [item]);
+    }
+    const order = ["Today", "Yesterday", "Earlier this week", "Older"];
+    return order
+      .filter((label) => map.has(label))
+      .map((label) => ({ label, items: map.get(label)! }));
+  }, [filtered]);
 
   return (
     <div className="w-full max-w-[640px] px-4">
@@ -70,9 +141,13 @@ export default function HistoryPanel({ items = SAMPLE_HISTORY, onSelect }: Histo
                    rounded-2xl overflow-hidden
                    shadow-[0_8px_32px_rgba(0,0,0,0.4),0_0_60px_rgba(173,198,255,0.04)]"
       >
-        {/* Header + Search */}
         <div className="p-5 pb-3 border-b border-outline-variant/10">
-          <h2 className="text-headline-sm font-semibold text-on-surface mb-3">History</h2>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-headline-sm font-semibold text-on-surface">History</h2>
+            <span className="text-label-sm text-on-surface-variant/60">
+              {loading ? "…" : `${items.length} session${items.length === 1 ? "" : "s"}`}
+            </span>
+          </div>
           <div className="relative">
             <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant/40 text-lg">
               search
@@ -88,50 +163,35 @@ export default function HistoryPanel({ items = SAMPLE_HISTORY, onSelect }: Histo
                          focus:border-primary/40 transition-colors duration-150"
             />
           </div>
-
-          {/* Filter pills */}
-          <div className="flex items-center gap-1.5 mt-3 overflow-x-auto">
-            <button
-              onClick={() => setFilterType(null)}
-              className={`px-3 py-1 rounded-full text-label-sm whitespace-nowrap transition-all duration-150
-                ${!filterType
-                  ? "bg-primary/15 text-primary border border-primary/30"
-                  : "text-on-surface-variant border border-outline-variant/10 hover:border-outline-variant/25"
-                }`}
-            >
-              All
-            </button>
-            {Object.entries(ICONS).map(([type, { icon, color }]) => (
-              <button
-                key={type}
-                onClick={() => setFilterType(filterType === type ? null : type)}
-                className={`flex items-center gap-1 px-3 py-1 rounded-full text-label-sm whitespace-nowrap transition-all duration-150
-                  ${filterType === type
-                    ? "bg-primary/15 text-primary border border-primary/30"
-                    : "text-on-surface-variant border border-outline-variant/10 hover:border-outline-variant/25"
-                  }`}
-              >
-                <span className={`material-symbols-outlined text-sm ${filterType === type ? "text-primary" : color}`}>{icon}</span>
-                {type.charAt(0).toUpperCase() + type.slice(1)}
-              </button>
-            ))}
-          </div>
         </div>
 
-        {/* History list */}
+        {error && (
+          <div className="mx-5 mt-3 text-label-md text-error bg-error/10 border border-error/20 rounded-lg px-3 py-2">
+            {error}
+          </div>
+        )}
+
         <div className="max-h-[400px] overflow-y-auto">
-          {groups.length === 0 ? (
-            <div className="p-8 text-center text-body-md text-on-surface-variant/50">
-              No matching history
+          {loading && (
+            <div className="p-8 text-center text-body-md text-on-surface-variant/60">
+              Loading history…
             </div>
-          ) : (
+          )}
+          {!loading && groups.length === 0 && (
+            <div className="p-8 text-center text-body-md text-on-surface-variant/50">
+              {searchQuery
+                ? "No matching history"
+                : "No conversations yet. Ask Sage something to start one."}
+            </div>
+          )}
+          {!loading &&
             groups.map((group) => (
               <div key={group.label}>
                 <div className="px-5 py-2 text-label-sm text-on-surface-variant/50 uppercase tracking-[0.05em]">
                   {group.label}
                 </div>
                 {group.items.map((item) => {
-                  const { icon, color } = ICONS[item.type] || ICONS.chat;
+                  const { icon, color } = ICONS[item.type];
                   return (
                     <button
                       key={item.id}
@@ -139,20 +199,25 @@ export default function HistoryPanel({ items = SAMPLE_HISTORY, onSelect }: Histo
                       className="w-full flex items-center gap-3 px-5 py-3 text-left
                                  hover:bg-surface-container-high/40 transition-colors duration-150"
                     >
-                      <span className={`material-symbols-outlined text-xl flex-shrink-0 ${color}`}>{icon}</span>
+                      <span className={`material-symbols-outlined text-xl flex-shrink-0 ${color}`}>
+                        {icon}
+                      </span>
                       <div className="flex-1 min-w-0">
                         <p className="text-body-md text-on-surface truncate">{item.title}</p>
                         {item.tomeName && (
-                          <p className="text-label-sm text-on-surface-variant/50 mt-0.5">{item.tomeName}</p>
+                          <p className="text-label-sm text-on-surface-variant/50 mt-0.5">
+                            {item.tomeName}
+                          </p>
                         )}
                       </div>
-                      <span className="text-label-sm text-on-surface-variant/40 flex-shrink-0">{item.timestamp}</span>
+                      <span className="text-label-sm text-on-surface-variant/40 flex-shrink-0">
+                        {item.timestamp}
+                      </span>
                     </button>
                   );
                 })}
               </div>
-            ))
-          )}
+            ))}
         </div>
       </div>
     </div>

--- a/frontend/src/components/KnowledgeBaseWidget.tsx
+++ b/frontend/src/components/KnowledgeBaseWidget.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  deleteDocument,
+  getDocument,
+  listDocuments,
+  type DocumentDetail,
+  type DocumentSummary,
+} from "@/lib/sage-api";
+import UploadModal from "./UploadModal";
+
+function formatDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString([], {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function KnowledgeBaseWidget() {
+  const [docs, setDocs] = useState<DocumentSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<DocumentDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+  const [uploadOpen, setUploadOpen] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listDocuments({ limit: 200 });
+      setDocs(data);
+      setSelectedId((prev) => (prev && data.some((d) => d.id === prev) ? prev : data[0]?.id ?? null));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    getDocument(selectedId)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((err) => {
+        if (!cancelled) setDetail(null);
+        console.error("Failed to load document detail:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
+
+  const handleDelete = async (docId: string) => {
+    setPendingDelete(docId);
+    try {
+      await deleteDocument(docId);
+      setDocs((prev) => prev.filter((d) => d.id !== docId));
+      if (selectedId === docId) {
+        setSelectedId(null);
+        setDetail(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPendingDelete(null);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-[960px] px-4">
+      <div
+        className="bg-surface/80 backdrop-blur-[32px] border border-outline-variant/15
+                   rounded-2xl overflow-hidden flex flex-col
+                   shadow-[0_8px_32px_rgba(0,0,0,0.4),0_0_60px_rgba(173,198,255,0.04)]"
+        style={{ height: "560px" }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-outline-variant/10">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary text-xl">database</span>
+            <h2 className="text-title-md font-medium text-on-surface">Knowledge base</h2>
+            <span className="text-label-sm text-on-surface-variant ml-1">
+              {loading ? "…" : `${docs.length} document${docs.length === 1 ? "" : "s"}`}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setUploadOpen(true)}
+              className="px-3 py-1 rounded-full text-label-sm text-primary
+                         border border-primary/30 hover:bg-primary/10 transition-colors"
+            >
+              <span className="material-symbols-outlined text-sm align-middle mr-1">upload_file</span>
+              Add document
+            </button>
+            <button
+              onClick={() => void refresh()}
+              disabled={loading}
+              className="px-3 py-1 rounded-full text-label-sm text-on-surface-variant
+                         border border-outline-variant/15 hover:border-outline-variant/30
+                         hover:text-on-surface transition-colors disabled:opacity-40"
+            >
+              <span className="material-symbols-outlined text-sm align-middle mr-1">refresh</span>
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <UploadModal
+          open={uploadOpen}
+          onClose={() => {
+            setUploadOpen(false);
+            void refresh();
+          }}
+        />
+
+        {error && (
+          <div className="mx-5 mt-3 text-label-md text-error bg-error/10 border border-error/20 rounded-lg px-3 py-2">
+            {error}
+          </div>
+        )}
+
+        {/* Body — two-pane */}
+        <div className="flex-1 flex overflow-hidden">
+          {/* List */}
+          <div className="w-[340px] border-r border-outline-variant/10 overflow-y-auto">
+            {loading && (
+              <div className="p-5 text-body-md text-on-surface-variant">Loading…</div>
+            )}
+            {!loading && docs.length === 0 && (
+              <div className="p-5 text-body-md text-on-surface-variant">
+                Nothing here yet. Click &ldquo;Add document&rdquo; above to upload one.
+              </div>
+            )}
+            {!loading &&
+              docs.map((doc) => {
+                const isActive = doc.id === selectedId;
+                return (
+                  <button
+                    key={doc.id}
+                    onClick={() => setSelectedId(doc.id)}
+                    className={`w-full text-left px-4 py-3 border-b border-outline-variant/10 transition-colors ${
+                      isActive
+                        ? "bg-primary/10 border-l-2 border-l-primary/60"
+                        : "hover:bg-surface-container-low"
+                    }`}
+                  >
+                    <div className="text-body-md text-on-surface truncate">{doc.title}</div>
+                    <div className="text-label-sm text-on-surface-variant mt-0.5 flex items-center gap-2">
+                      <span className="uppercase tracking-wide">{doc.doc_type}</span>
+                      <span>·</span>
+                      <span>{doc.source}</span>
+                    </div>
+                    <div className="text-label-sm text-on-surface-variant/60 mt-0.5">
+                      {formatDate(doc.created_at)}
+                    </div>
+                  </button>
+                );
+              })}
+          </div>
+
+          {/* Detail */}
+          <div className="flex-1 overflow-y-auto p-5">
+            {!selectedId && !loading && (
+              <div className="text-body-md text-on-surface-variant">
+                Select a document to view details.
+              </div>
+            )}
+            {selectedId && detailLoading && (
+              <div className="text-body-md text-on-surface-variant">Loading details…</div>
+            )}
+            {detail && !detailLoading && (
+              <div className="flex flex-col gap-4">
+                <div>
+                  <div className="text-headline-sm text-on-surface">{detail.title}</div>
+                  <div className="text-label-sm text-on-surface-variant mt-1">
+                    {formatDate(detail.created_at)}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <Stat label="Source" value={detail.source} />
+                  <Stat label="Type" value={detail.doc_type} />
+                  <Stat label="Chunks" value={String(detail.chunks)} />
+                  <Stat
+                    label="Content hash"
+                    value={detail.content_hash.slice(0, 12) + "…"}
+                    mono
+                  />
+                </div>
+
+                <div>
+                  <div className="text-label-md text-on-surface-variant mb-1">Tomes</div>
+                  {detail.tomes.length === 0 ? (
+                    <div className="text-body-md text-on-surface-variant/70">
+                      Not linked to any tome.
+                    </div>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                      {detail.tomes.map((t) => (
+                        <span
+                          key={t.id}
+                          className="text-label-sm bg-surface-container-low border border-outline-variant/15
+                                     rounded-full px-2.5 py-1 text-on-surface-variant"
+                        >
+                          {t.name}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <div className="text-label-md text-on-surface-variant mb-1">Preview</div>
+                  <div
+                    className="text-body-md text-on-surface whitespace-pre-wrap bg-surface-container-low
+                               border border-outline-variant/10 rounded-xl px-3 py-2 leading-relaxed"
+                  >
+                    {detail.content_preview || "(empty)"}
+                  </div>
+                </div>
+
+                <div className="pt-2 border-t border-outline-variant/10 flex justify-end">
+                  <button
+                    onClick={() => void handleDelete(detail.id)}
+                    disabled={pendingDelete === detail.id}
+                    className="px-3 py-1.5 rounded-full text-label-md text-error
+                               border border-error/30 hover:bg-error/10
+                               disabled:opacity-40 transition-colors"
+                  >
+                    <span className="material-symbols-outlined text-sm align-middle mr-1">
+                      delete
+                    </span>
+                    {pendingDelete === detail.id ? "Deleting…" : "Delete document"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="bg-surface-container-low border border-outline-variant/10 rounded-lg px-3 py-2">
+      <div className="text-label-sm text-on-surface-variant">{label}</div>
+      <div className={`text-body-md text-on-surface truncate ${mono ? "font-mono" : ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/QuizView.tsx
+++ b/frontend/src/components/QuizView.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import QuizWidget from "./QuizWidget";
+import {
+  generateQuiz,
+  type GeneratedQuizQuestion,
+  type GeneratedSource,
+} from "@/lib/sage-api";
+
+interface QuizViewProps {
+  prompt: string;
+  tomeId?: string;
+  count?: number;
+}
+
+export default function QuizView({ prompt, tomeId, count = 5 }: QuizViewProps) {
+  const [questions, setQuestions] = useState<GeneratedQuizQuestion[] | null>(null);
+  const [sources, setSources] = useState<GeneratedSource[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setQuestions(null);
+    setError(null);
+    setSources([]);
+    generateQuiz({ topic: prompt || undefined, tomeId, count })
+      .then((res) => {
+        if (cancelled) return;
+        setQuestions(res.questions);
+        setSources(res.sources);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [prompt, tomeId, count, reloadKey]);
+
+  if (error) {
+    return (
+      <StatusCard
+        icon="error"
+        title="Couldn't generate quiz"
+        detail={error}
+        onRetry={() => setReloadKey((k) => k + 1)}
+      />
+    );
+  }
+
+  if (!questions) {
+    return <StatusCard icon="hourglass_top" title="Generating quiz…" detail="Searching your knowledge base and writing questions." />;
+  }
+
+  const title = prompt.trim() ? `Quiz: ${prompt.trim()}` : "Quiz";
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <QuizWidget title={title} questions={questions} />
+      {sources.length > 0 && <SourcesFooter sources={sources} />}
+    </div>
+  );
+}
+
+function StatusCard({
+  icon, title, detail, onRetry,
+}: { icon: string; title: string; detail?: string; onRetry?: () => void }) {
+  return (
+    <div className="w-full max-w-[640px] px-4">
+      <div className="bg-surface/80 backdrop-blur-[32px] border border-outline-variant/15 rounded-2xl px-6 py-8
+                      shadow-[0_8px_32px_rgba(0,0,0,0.4)] flex flex-col items-center gap-2 text-center">
+        <span className="material-symbols-outlined text-primary text-3xl">{icon}</span>
+        <div className="text-title-md text-on-surface">{title}</div>
+        {detail && <div className="text-body-md text-on-surface-variant max-w-[480px]">{detail}</div>}
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 px-3 py-1 rounded-full text-label-md border border-outline-variant/20
+                       text-on-surface-variant hover:border-primary/40 hover:text-on-surface transition-colors"
+          >
+            Try again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourcesFooter({ sources }: { sources: GeneratedSource[] }) {
+  const unique = Array.from(new Map(sources.map((s) => [s.document_id, s])).values());
+  return (
+    <div className="w-full max-w-[640px] px-4 text-label-sm text-on-surface-variant flex flex-wrap gap-1.5 justify-center">
+      <span className="text-on-surface-variant/60">Grounded in:</span>
+      {unique.map((s) => (
+        <span
+          key={s.document_id}
+          className="bg-surface-container-low border border-outline-variant/10 rounded-full px-2.5 py-0.5"
+        >
+          {s.document_title}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ReportView.tsx
+++ b/frontend/src/components/ReportView.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ReportViewWidget from "./ReportViewWidget";
+import {
+  generateReport,
+  type GeneratedSource,
+  type ReportGeneration,
+} from "@/lib/sage-api";
+
+interface ReportViewProps {
+  prompt: string;
+  tomeId?: string;
+}
+
+export default function ReportView({ prompt, tomeId }: ReportViewProps) {
+  const [report, setReport] = useState<ReportGeneration | null>(null);
+  const [sources, setSources] = useState<GeneratedSource[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setReport(null);
+    setError(null);
+    setSources([]);
+    generateReport({ topic: prompt || undefined, tomeId })
+      .then((res) => {
+        if (cancelled) return;
+        setReport(res);
+        setSources(res.sources);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [prompt, tomeId, reloadKey]);
+
+  if (error) {
+    return (
+      <StatusCard
+        icon="error"
+        title="Couldn't generate report"
+        detail={error}
+        onRetry={() => setReloadKey((k) => k + 1)}
+      />
+    );
+  }
+
+  if (!report) {
+    return (
+      <StatusCard
+        icon="hourglass_top"
+        title="Generating report…"
+        detail="Synthesizing your knowledge base into a structured report."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 w-full">
+      <ReportViewWidget
+        report={{
+          title: report.title,
+          subtitle: report.subtitle ?? undefined,
+          sourceDocs: report.sourceDocs ?? undefined,
+          toc: report.toc,
+          content: report.content,
+        }}
+      />
+      {sources.length > 0 && <SourcesFooter sources={sources} />}
+    </div>
+  );
+}
+
+function StatusCard({
+  icon, title, detail, onRetry,
+}: { icon: string; title: string; detail?: string; onRetry?: () => void }) {
+  return (
+    <div className="w-full max-w-[640px] px-4">
+      <div className="bg-surface/80 backdrop-blur-[32px] border border-outline-variant/15 rounded-2xl px-6 py-8
+                      shadow-[0_8px_32px_rgba(0,0,0,0.4)] flex flex-col items-center gap-2 text-center">
+        <span className="material-symbols-outlined text-primary text-3xl">{icon}</span>
+        <div className="text-title-md text-on-surface">{title}</div>
+        {detail && <div className="text-body-md text-on-surface-variant max-w-[480px]">{detail}</div>}
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 px-3 py-1 rounded-full text-label-md border border-outline-variant/20
+                       text-on-surface-variant hover:border-primary/40 hover:text-on-surface transition-colors"
+          >
+            Try again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourcesFooter({ sources }: { sources: GeneratedSource[] }) {
+  const unique = Array.from(new Map(sources.map((s) => [s.document_id, s])).values());
+  return (
+    <div className="w-full max-w-[800px] px-4 text-label-sm text-on-surface-variant flex flex-wrap gap-1.5 justify-center">
+      <span className="text-on-surface-variant/60">Grounded in:</span>
+      {unique.map((s) => (
+        <span
+          key={s.document_id}
+          className="bg-surface-container-low border border-outline-variant/10 rounded-full px-2.5 py-0.5"
+        >
+          {s.document_title}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ingestDocument } from "@/lib/sage-api";
+
+interface UploadModalProps {
+  open: boolean;
+  onClose: () => void;
+  tomeId?: string;
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "uploading" }
+  | { kind: "success"; title: string; chunks: number; deduplicated: boolean }
+  | { kind: "error"; message: string };
+
+const TEXT_EXTENSIONS = [".txt", ".md", ".markdown", ".rst", ".csv", ".json", ".log"];
+
+export default function UploadModal({ open, onClose, tomeId }: UploadModalProps) {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [filename, setFilename] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setTitle("");
+      setContent("");
+      setFilename("");
+      setStatus({ kind: "idle" });
+      setDragOver(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  const readFile = async (file: File) => {
+    const name = file.name;
+    const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
+    if (!TEXT_EXTENSIONS.includes(ext) && !file.type.startsWith("text/")) {
+      setStatus({
+        kind: "error",
+        message: `Unsupported file type "${ext || file.type}". Use plain text (.txt, .md, .csv, .json) or paste content directly.`,
+      });
+      return;
+    }
+    const text = await file.text();
+    setContent(text);
+    setFilename(name);
+    if (!title.trim()) setTitle(name.replace(/\.[^.]+$/, ""));
+    setStatus({ kind: "idle" });
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void readFile(file);
+    e.target.value = "";
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) void readFile(file);
+  };
+
+  const handleSubmit = async () => {
+    const finalTitle = title.trim() || filename || "Untitled";
+    const finalContent = content.trim();
+    if (!finalContent) {
+      setStatus({ kind: "error", message: "Add some content first." });
+      return;
+    }
+    setStatus({ kind: "uploading" });
+    try {
+      const res = await ingestDocument(finalTitle, finalContent, {
+        docType: filename ? "file" : "text",
+        sourceId: filename || "",
+        tomeId,
+      });
+      setStatus({
+        kind: "success",
+        title: res.title,
+        chunks: res.chunks,
+        deduplicated: res.deduplicated,
+      });
+      setContent("");
+      setTitle("");
+      setFilename("");
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[640px] mx-4 bg-surface border border-outline-variant/20 rounded-2xl
+                   shadow-[0_16px_48px_rgba(0,0,0,0.5)] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-outline-variant/10">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary text-xl">upload_file</span>
+            <h2 className="text-title-md font-medium text-on-surface">Add to knowledge base</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-lg text-on-surface-variant hover:bg-surface-container-low transition-colors"
+            aria-label="Close"
+          >
+            <span className="material-symbols-outlined text-lg">close</span>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5 flex flex-col gap-4">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Document title"
+            className="bg-surface-container-low border border-outline-variant/10 rounded-xl px-3 py-2
+                       text-body-md text-on-surface placeholder:text-on-surface-variant/50
+                       outline-none focus:border-primary/40 transition-colors"
+          />
+
+          <div
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragOver(true);
+            }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={handleDrop}
+            className={`rounded-xl border border-dashed transition-colors p-4 flex flex-col gap-2 ${
+              dragOver
+                ? "border-primary/60 bg-primary/5"
+                : "border-outline-variant/25 bg-surface-container-low"
+            }`}
+          >
+            <div className="flex items-center justify-between text-label-sm text-on-surface-variant">
+              <span>
+                {filename
+                  ? `Loaded: ${filename}`
+                  : "Drop a text file here, or paste content below"}
+              </span>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="px-2.5 py-1 rounded-md border border-outline-variant/15
+                           hover:border-primary/30 hover:text-on-surface transition-colors"
+              >
+                Choose file
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".txt,.md,.markdown,.rst,.csv,.json,.log,text/*"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+            </div>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Paste document content..."
+              rows={10}
+              className="bg-transparent text-body-md text-on-surface placeholder:text-on-surface-variant/50
+                         outline-none resize-y leading-relaxed"
+            />
+          </div>
+
+          {status.kind === "error" && (
+            <div className="text-label-md text-error bg-error/10 border border-error/20 rounded-lg px-3 py-2">
+              {status.message}
+            </div>
+          )}
+          {status.kind === "success" && (
+            <div className="text-label-md text-primary bg-primary/10 border border-primary/20 rounded-lg px-3 py-2">
+              {status.deduplicated
+                ? `Already in knowledge base: "${status.title}" (${status.chunks} chunks).`
+                : `Ingested "${status.title}" — ${status.chunks} chunks indexed.`}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-outline-variant/10 flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 rounded-full text-label-md text-on-surface-variant
+                       border border-outline-variant/15 hover:border-outline-variant/30
+                       hover:text-on-surface transition-colors"
+          >
+            Close
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={status.kind === "uploading" || !content.trim()}
+            className="px-4 py-1.5 rounded-full text-label-md bg-primary/20 border border-primary/30
+                       text-primary hover:bg-primary/30 transition-colors
+                       disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            {status.kind === "uploading" ? "Uploading..." : "Add to knowledge base"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/sage-api.ts
+++ b/frontend/src/lib/sage-api.ts
@@ -112,6 +112,17 @@ async function apiFetch<T>(path: string, opts: FetchOpts = {}): Promise<T> {
   return res.json();
 }
 
+// ── Config ──
+
+export interface SageRuntimeConfig {
+  provider: string;
+  model: string;
+}
+
+export async function getRuntimeConfig(): Promise<SageRuntimeConfig> {
+  return apiFetch<SageRuntimeConfig>("/api/config");
+}
+
 // ── Tomes ──
 
 export interface Tome {
@@ -181,6 +192,42 @@ export async function ingestDocument(
   });
 }
 
+export interface DocumentSummary {
+  id: string;
+  title: string;
+  source: string;
+  doc_type: string;
+  content_hash: string;
+  created_at: string;
+}
+
+export interface DocumentDetail extends DocumentSummary {
+  chunks: number;
+  content_preview: string;
+  tomes: { id: string; name: string }[];
+}
+
+export async function listDocuments(
+  opts: { limit?: number; offset?: number } = {},
+): Promise<DocumentSummary[]> {
+  const params = new URLSearchParams();
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts.offset !== undefined) params.set("offset", String(opts.offset));
+  const qs = params.toString();
+  const data = await apiFetch<{ documents: DocumentSummary[] }>(
+    `/api/knowledge/documents${qs ? `?${qs}` : ""}`,
+  );
+  return data.documents;
+}
+
+export async function getDocument(docId: string): Promise<DocumentDetail> {
+  return apiFetch<DocumentDetail>(`/api/knowledge/documents/${docId}`);
+}
+
+export async function deleteDocument(docId: string): Promise<void> {
+  await apiFetch(`/api/knowledge/documents/${docId}`, { method: "DELETE" });
+}
+
 export async function searchKnowledge(
   query: string, opts: { maxResults?: number; tomeId?: string } = {},
 ): Promise<{ results: unknown[]; formatted: string }> {
@@ -192,6 +239,175 @@ export async function searchKnowledge(
       tome_id: opts.tomeId ?? null,
     },
   });
+}
+
+// ── Chat sessions / history ──
+
+export interface ChatSessionSummary {
+  id: string;
+  tome_id: string | null;
+  tome_name: string | null;
+  provider: string;
+  model: string;
+  created_at: string;
+  last_message_at: string;
+  first_user_message: string | null;
+  message_count: number;
+}
+
+export async function listChatSessions(limit = 100): Promise<ChatSessionSummary[]> {
+  const data = await apiFetch<{ sessions: ChatSessionSummary[] }>(
+    `/api/chat/sessions?limit=${limit}`,
+  );
+  return data.sessions;
+}
+
+// ── Generation: flashcards & quizzes ──
+
+export interface GeneratedFlashcard {
+  id: string;
+  front: string;
+  back: string;
+}
+
+export interface GeneratedSource {
+  document_id: string;
+  document_title: string;
+  chunk_index: number;
+  similarity: number | null;
+}
+
+export interface FlashcardGeneration {
+  cards: GeneratedFlashcard[];
+  topic: string;
+  sources: GeneratedSource[];
+}
+
+export interface GeneratedQuizOption {
+  id: string;
+  text: string;
+}
+
+export interface GeneratedQuizQuestion {
+  id: string;
+  question: string;
+  options: GeneratedQuizOption[];
+  correctOptionId: string;
+  explanation?: string;
+}
+
+export interface QuizGeneration {
+  questions: GeneratedQuizQuestion[];
+  topic: string;
+  sources: GeneratedSource[];
+}
+
+export interface GenerateOpts {
+  topic?: string;
+  tomeId?: string;
+  count?: number;
+  provider?: string;
+  model?: string;
+}
+
+function generateBody(opts: GenerateOpts) {
+  return {
+    topic: opts.topic ?? null,
+    tome_id: opts.tomeId ?? null,
+    count: opts.count ?? 6,
+    provider: opts.provider ?? null,
+    model: opts.model ?? null,
+  };
+}
+
+export async function generateFlashcards(opts: GenerateOpts = {}): Promise<FlashcardGeneration> {
+  return apiFetch<FlashcardGeneration>("/api/generate/flashcards", {
+    method: "POST",
+    body: generateBody(opts),
+  });
+}
+
+export async function generateQuiz(opts: GenerateOpts = {}): Promise<QuizGeneration> {
+  return apiFetch<QuizGeneration>("/api/generate/quiz", {
+    method: "POST",
+    body: generateBody(opts),
+  });
+}
+
+// ── Generation: reports ──
+
+export interface ReportTocItem {
+  id: string;
+  title: string;
+}
+
+export interface ReportGeneration {
+  title: string;
+  subtitle: string | null;
+  sourceDocs: string | null;
+  toc: ReportTocItem[];
+  content: string;
+  sources: GeneratedSource[];
+  topic: string;
+}
+
+export async function generateReport(opts: GenerateOpts = {}): Promise<ReportGeneration> {
+  return apiFetch<ReportGeneration>("/api/generate/report", {
+    method: "POST",
+    body: generateBody(opts),
+  });
+}
+
+// ── Generation: audio narration ──
+
+export interface AudioSegment {
+  id: string;
+  text: string;
+  startTime: number;
+  endTime: number;
+}
+
+export interface AudioGeneration {
+  id: string;
+  title: string;
+  voice: string;
+  provider: string;
+  model: string;
+  script: string;
+  segments: AudioSegment[];
+  duration: number;
+  /** Backend-relative URL to an MP3 (OpenAI TTS). When null, the frontend
+   *  falls back to browser SpeechSynthesis for playback. */
+  audio_url: string | null;
+  sources: GeneratedSource[];
+  topic: string;
+}
+
+export interface GenerateAudioOpts {
+  topic?: string;
+  tomeId?: string;
+  voice?: string;
+  provider?: string;
+  model?: string;
+}
+
+export async function generateAudio(opts: GenerateAudioOpts = {}): Promise<AudioGeneration> {
+  return apiFetch<AudioGeneration>("/api/generate/audio", {
+    method: "POST",
+    body: {
+      topic: opts.topic ?? null,
+      tome_id: opts.tomeId ?? null,
+      voice: opts.voice ?? null,
+      provider: opts.provider ?? null,
+      model: opts.model ?? null,
+    },
+  });
+}
+
+/** Resolve a relative audio path to a fully-qualified URL using the active API base. */
+export function resolveAudioUrl(path: string): string {
+  if (/^https?:/i.test(path)) return path;
+  return `${getApiBaseUrl()}${path.startsWith("/") ? "" : "/"}${path}`;
 }
 
 // ── Chat ──


### PR DESCRIPTION
## Summary

This branch replaces every placeholder fixture in the Sage app with a real backend round-trip and adds the foundational endpoints, UI surfaces, and developer tooling that the rest of the product can build on. The original `SAMPLE_*` arrays for flashcards, quizzes, chat, history, and audio are gone — every view now fetches live, KB-grounded data from the FastAPI backend.

There is one feature doc per area under [`docs/`](./docs/), and each commit message corresponds to one of those docs.

<img width="843" height="452" alt="image" src="https://github.com/user-attachments/assets/4a81dac7-b7dc-4547-a98c-8deb8be50acd" />


## What changed

### Backend (FastAPI)

- **Generation endpoints** — `POST /api/generate/{flashcards,quiz,report}`. Each retrieves excerpts from the user's KB (semantic search when a topic is provided, random sample otherwise — optionally scoped to a tome), calls the configured LLM with `response_format=json_object` on OpenAI-compatible providers, and validates the parsed payload before responding. Empty KB → `400` with a hint to upload documents.
- **Audio narration + TTS** — `POST /api/generate/audio` returns a spoken-style narration script with sentence-level segments and word-rate-estimated timings. When `OPENAI_API_KEY` is set, it also synthesizes an MP3 via `tts-1` and caches it; `GET /api/audio/{id}.mp3` streams it back with a regex guard against directory traversal.
- **Chat sessions endpoint** — `GET /api/chat/sessions` backed by a new `KnowledgeStore.list_sessions()` that joins `sessions × messages × tomes` in one SQL pass and returns derived titles, tome name, message count, and last-activity timestamp.
- **Capability-aware system prompt** — chat `SYSTEM_PROMPT` now lists every routing keyword and the view it opens, so the model can describe its own routed features when asked "what can you do?" and stays silent when the frontend has already routed away.

### Frontend (Next.js / Tauri)

- **Knowledge-base UI** — new `UploadModal` (paste / drag-drop / file-picker for text-like files, deduped server-side by content hash) and `KnowledgeBaseWidget` (two-pane list + detail browser with per-row delete). Reachable via a new circular button next to the command-bar pill *and* via the verb router (`knowledge`, `kb`, `docs`, …).
- **Live views** — `FlashcardsView`, `QuizView`, `AudioView`, `ReportView` are all real fetch wrappers around the matching `/api/generate/*` endpoint. Each renders loading / error-with-retry / content states and a "Grounded in: …" source footer.
- **Real audio player** — `AudioPlayerWidget` now supports two playback modes: a hidden `<audio>` element when the backend returned an MP3 (with a Download link), and a `SpeechSynthesis` fallback when no key is configured (with a "Browser TTS" badge). Transcript scroll-lock works in both modes.
- **Real chat round-trip** — `ChatWidget` calls `sendChat()`, tracks `sessionId` across turns, surfaces backend errors inline, and accepts `initialQuery` so the user's first command-bar prompt seeds the conversation.
- **Shared in-chat command routing** — `detectView()` is lifted into `page.tsx` and exposed to `ChatWidget` via `onCommand`, so typing "make flashcards on attention" from inside the chat view routes to the flashcards view instead of being answered as prose. The model badge in `CommandBar` and `ChatWidget` is driven by `getRuntimeConfig()` instead of being hard-coded.
- **History panel** — `HistoryPanel` now reads `GET /api/chat/sessions`, filters out empty stub sessions, derives titles from the first user message, and groups rows into Today / Yesterday / Earlier this week / Older.
- **Sage API client** — `src/lib/sage-api.ts` gets typed helpers for every new endpoint (knowledge, generation, audio, history) plus a `resolveAudioUrl()` that works from both the Next.js dev server and the Tauri sidecar.

### Tooling

- **Agentation dev panel** — `agentation` added as a devDependency; a small `<AgentationDev />` wrapper mounted at the end of `<body>` renders only when `NODE_ENV === "development"`, so the in-app feedback overlay never ships in a production build.

### Docs

Per-feature reference notes under [`docs/`](./docs/) — one file per feature area, each with a "Files touched" section so reviewers can map features to diffs quickly:

- `README.md` (index)
- `agentation.md`
- `chat-backend-integration.md`
- `knowledge-base-ui.md`
- `in-chat-command-routing.md`
- `generation-endpoints.md`
- `audio-generation.md`
- `history-panel.md`

## Test plan

- [ ] `cd backend && uvicorn main:app` boots without import errors.
- [ ] `GET /` returns OK; `GET /api/config` returns provider/model.
- [ ] Upload a `.md` file via the round button → it appears in `KnowledgeBaseWidget` with the expected chunk count and content hash.
- [ ] Re-upload the same file → the response says "already in knowledge base".
- [ ] Type `flashcards on attention` in the command bar with a non-empty KB → real cards appear with a "Grounded in: …" footer; empty KB → an error card pointing at upload.
- [ ] Same for `quiz on transformers`, `report on attention`, `audio on backpropagation`.
- [ ] With `OPENAI_API_KEY` set, the audio view streams an MP3 and exposes a Download link; without one, the SpeechSynthesis fallback runs and the badge reads "Browser TTS".
- [ ] Type `flashcards` inside the chat view → it routes to the flashcards view, no chat reply is generated.
- [ ] Ask the chat "what can you do?" → it lists the routed features accurately from the new capability prompt section.
- [ ] `HistoryPanel` shows real conversations, grouped by Today / Yesterday / Earlier this week / Older; search filters by title and tome name.
- [ ] `npm run build` in `frontend/` succeeds; `npx tsc --noEmit` is clean.
- [ ] Production build does **not** include the Agentation overlay.

## Known leftovers / explicitly out of scope

- One unrelated local edit to `frontend/src-tauri/tauri.conf.json` (removal of `identifier`) is **not** included — it would break Tauri builds, so it's kept in the working tree for the author to triage.
- No persistence for generated quizzes / flashcards / audio / reports yet — they live in React state. History therefore only contains chat rows; the `HistoryItem["type"]` union and ICON map are pre-shaped to extend.
- PDF/DOCX/image upload is still TODO — the ingest endpoint takes a string. The cleanest path is a new `multipart/form-data` endpoint that calls the existing `PDFService.extract_text` and forwards into the ingest pipeline.

## Where to go next

All the groundwork is in place to take Sage from "real, working scaffold" to a genuinely exceptional product. The two highest-leverage follow-ups:

### 1. Deploy on Vercel

Make an account on https://vercel.com/ and connect it to this repository so that you can host the web app publicly. (This is free!)

### 2. Make Tomes a real, first-class feature

The schema, store methods, and tome-aware retrieval already exist (`create_tome`, `link_to_tome`, `get_tome_documents`, `get_tome_document_ids`, `tome_id` on `SearchDocsSkill`, etc.), and every `/api/generate/*` endpoint already accepts a `tome_id`. What's missing is the *application layer* on top:

- **Active-tome state at the page level**, threaded through `CommandBar`, `ChatWidget`, `UploadModal`, and all `*View` components, so uploads and generations are scoped by default instead of polluting the global KB.
- **Tome management UI** — a richer `TomeSelector` with create / rename / delete / set-active, drag-to-link documents from the KB browser, and an "active tome" pill in the header.
- **Per-tome dashboards** — a tome view that shows linked documents, recent sessions in that tome (the `list_sessions` query already filters by `tome_id`), and one-click "make a quiz / flashcards / report from this tome".
- **Persistence for generated artifacts** scoped to a tome — once quizzes, flashcards, audio, and reports are stored, the History panel can show them filtered by tome, and the unioned `HistoryItem["type"]` will start carrying real diversity.
- **Tome-scoped chat sessions surfaced in History** — already supported by the store; UI just needs to surface the tome name and let users resume a session in its original tome.

### 3. Begin integrating more advanced ML models

The provider abstraction (`providers/factory.py`, `providers/base.py`) and the skill registry (`skills/base.py`, `SearchDocsSkill`) are deliberately model-agnostic. That makes the next ML upgrades incremental, not architectural:

- **Smarter retrieval** — swap the current embedding model for a stronger one (e.g., `text-embedding-3-large` or `bge-large-en-v1.5`), add a re-ranker (`bge-reranker` or `cohere/rerank`) between `SearchDocsSkill` and the LLM, and add hybrid BM25 + dense scoring on top of the existing chunk table.
- **Better grounding** — span-level citations instead of document-level ones. Every `/api/generate/*` endpoint already passes `chunk_index` through to the response; the next step is to have the LLM emit `[doc:chunk]` markers and render real footnotes in `FlashcardsView` / `QuizView` / `ReportView`.
- **Native PDF / DOCX / image ingest** — wire `PDFService.extract_text` (already used by the arXiv flow) into a `multipart/form-data` endpoint, then layer in OCR (Tesseract or a vision LLM) and table-aware parsers (`unstructured`, `pdfplumber`).
- **Long-context / summarization upgrades** — the report generator is currently single-shot. Plug in a map-reduce summarizer (or just route to a long-context model for tomes above a chunk threshold) for materially better study guides.
- **Agentic skill expansion** — the `SkillRegistry` is the right place to add `web_fetch`, `arxiv_search`, `wolfram_alpha`, etc. The chat orchestrator already supports tool-calls; new skills are additive.
- **Eval harness** — with everything grounded in `KnowledgeStore`, it's now cheap to wire a small eval set per skill (retrieval recall@k, quiz answer accuracy, report faithfulness) so each model upgrade can be measured rather than vibed.