### PR TITLE
feat: add redesigned Tome Home surface

### DIFF
--- a/AGENT_SKILL_SPEC.md
+++ b/AGENT_SKILL_SPEC.md
@@ -20,6 +20,28 @@ User Query → Agent Orchestrator → LLM selects tool → Skill executes → Sk
                                                          matching React card
 ```
 
+## Frontend Surface Hierarchy
+
+The frontend has three conceptual layers:
+
+1. **Tome Home**
+   - Default in-app landing surface.
+   - Collects user intent through a large composer and visible capability chips.
+   - Routes natural-language prompts or capability clicks into focused skill views.
+
+2. **Focused Skill Views**
+   - Render skill outputs such as `ChatWidget`, `ReportViewWidget`, `QuizWidget`, `FlashcardWidget`, `AudioPlayerWidget`, `HistoryPanel`, and `TomeSelector`.
+   - These are the primary targets for `SkillResult.ui_component`.
+
+3. **Global Command Bar**
+   - Future macOS desktop overlay.
+   - Uses the same backend skill/orchestrator contract.
+   - Can route into Tome Home or directly into a focused skill view.
+
+Tome Home itself should remain the neutral starting state; do not treat it as a normal skill result component unless a future route-level registry is added.
+
+---
+
 ### SkillResult Contract
 
 ```python
@@ -44,17 +66,29 @@ const COMPONENT_REGISTRY: Record<string, React.ComponentType<any>> = {
   "ReportViewWidget": ReportViewWidget,
   "HistoryPanel": HistoryPanel,
   "TomeSelector": TomeSelector,
-  "CommandBar": CommandBar,
+  "CommandBar": CommandBar, // future/global overlay entry point
 };
 ```
 
 When a `SkillResult` arrives:
-1. If `ui_component` is set → render the matching card with `data` as props
+1. If `ui_component` is set → route to the matching focused view/card with `data` as props
 2. If `ui_component` is null → append `content` as a markdown chat message
+3. Tome Home remains the neutral starting surface; skill results should not replace it permanently
 
 ---
 
 ## 2. Component Inventory
+
+### 2.0 App-Level Surfaces
+
+These currently live in `frontend/src/app/page.tsx`:
+
+| Surface | Role |
+|---------|------|
+| **TomeHome** | Default composer-first home after opening Sage or selecting a Tome |
+| **TomeDashboard** | Secondary overview for artifact/source status and generated work management |
+| **TopBar** | Navigation among Home, Dashboard, History, and Tomes |
+| **FocusShell** | Wrapper that hosts focused skill views and returns to Tome Home |
 
 ### 2.1 Ethereal Console Components (DESIGN.md compliant ✅)
 
@@ -62,7 +96,7 @@ These 8 components follow the glassmorphic "Ethereal Console" design system — 
 
 | # | Component | File | Status | Description |
 |---|-----------|------|--------|-------------|
-| 1 | **CommandBar** | `CommandBar.tsx` | ✅ Ready | Pill input bar (600×48px), sparkle icon, provider badge. The entry point. |
+| 1 | **CommandBar** | `CommandBar.tsx` | ✅ Ready | Pill input bar. Future global overlay entry point / reusable command input. |
 | 2 | **ChatWidget** | `ChatWidget.tsx` | ✅ Ready | Chat card with message bubbles, typing indicator, auto-scroll. Has sample data. |
 | 3 | **QuizWidget** | `QuizWidget.tsx` | ✅ Ready | Interactive quiz with progress dots, confirm/skip flow, completion ring. |
 | 4 | **FlashcardWidget** | `FlashcardWidget.tsx` | ✅ Ready | 3D flip cards (Framer Motion), shuffle/reset, keyboard nav (arrows + space). |

--- a/BRAINSTORM.md
+++ b/BRAINSTORM.md
@@ -8,7 +8,7 @@
 
 **Architecture**: Tauri desktop app (Next.js + Tailwind frontend, FastAPI backend)
 **What it does**: Search arXiv → download PDFs → extract text → summarize with DeepSeek → Instagram-style feed
-**Strengths**: 
+**Strengths**:
 - Working Tauri desktop app (cross-platform)
 - Clean FastAPI backend with caching
 - PDF extraction pipeline (pdfplumber)
@@ -26,8 +26,19 @@
 
 ## The Vision: "Sage" — Local Knowledge Agent
 
+### Updated UI Direction: Tome Home + Command Overlay
+
+The current product direction is not “only a floating palette.” Sage should have a calm default Tome Home for focused work, plus a lightweight global command overlay for quick macOS interactions.
+
+- **Tome Home**: default in-app surface after opening Sage or selecting a Tome.
+- **Tome Dashboard**: secondary overview, not the first impression.
+- **Command overlay**: Spotlight/Raycast-style hotkey layer for quick search, capture, and skill launch.
+- **Web version**: out of scope for now; browser mode is a development convenience.
+
+See `docs/PRODUCT_SURFACES.md` for current surface hierarchy.
+
 ### Core Idea
-A local-first desktop app where users:
+A local-first macOS desktop app where users:
 1. **Import documents** (PDFs, markdown, Obsidian vault, web clips, etc.) into a local knowledge store
 2. **Connect any agent provider** (OpenAI, Anthropic, local Ollama, DeepSeek, etc.) via BYOA config
 3. **Use skills/tools** that the app supplies to the agent, enabling: quizzes, flashcards, reports, Q&A, comparisons, timelines, and more
@@ -172,7 +183,7 @@ CREATE TABLE messages (
 ```python
 class AgentProvider(ABC):
     """Abstract interface for any LLM provider."""
-    
+
     @abstractmethod
     async def chat(
         self,
@@ -201,22 +212,22 @@ class AgentProvider(ABC):
 # ~/.sage/config.yaml
 providers:
   default: "ollama"
-  
+
   ollama:
     base_url: "http://localhost:11434"
     default_model: "llama3.1:8b"
-    
+
   openai:
     api_key: "${OPENAI_API_KEY}"
     default_model: "gpt-4o-mini"
-    
+
   anthropic:
     api_key: "${ANTHROPIC_API_KEY}"
     default_model: "claude-sonnet-4-20250514"
 
 knowledge_store:
   path: "~/.sage/knowledge.db"
-  
+
 obsidian:
   vault_path: "~/Documents/ObsidianVault"
   sync_interval: 300  # seconds

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,32 @@ No 1px solid borders for internal sectioning. Boundaries are defined through **b
 
 ---
 
+
+## Product Surface Model
+
+Sage now has two complementary desktop surfaces:
+
+1. **Tome Home — default in-app surface**
+   - Calm, centered, composer-first, and Tome-aware.
+   - Appears after opening Sage or selecting a Tome.
+   - Provides natural-language input, visible capability chips, selected Tome context, and a path to the expanded dashboard.
+   - Optimized for deliberate work inside a Tome.
+
+2. **Global Command Bar — OS overlay**
+   - Spotlight/Raycast-style layer invoked by a macOS global hotkey.
+   - Used for quick capture, search, opening a Tome, or launching a skill from anywhere.
+   - Lightweight and transient; it can route into Tome Home or focused skill views when deeper work is needed.
+
+Tome Home does **not** replace the command bar. It gives Sage a calmer home base, while the command bar preserves the original “intelligence layer over the OS” direction.
+
+3. **Focused Views**
+   - Deep-work surfaces for chat, reports, quizzes, flashcards, audio, history, sources/Tomes, and future skills.
+   - These are the primary render targets for backend skill results.
+
+Near-term interaction design should optimize for macOS desktop. Browser rendering remains useful for frontend development, but a hosted web product is out of scope for now.
+
+---
+
 ## Design Tokens
 
 ### Color Palette (Dark Only)
@@ -89,7 +115,29 @@ No 1px solid borders for internal sectioning. Boundaries are defined through **b
 
 The floating window is a **card stack**. The input bar is always the bottom layer; content cards stack on top based on interaction.
 
-### State 1: Compact Input (Default)
+
+### State 0: Tome Home
+
+Default in-app surface after opening Sage or selecting a Tome.
+
+```
+Good afternoon, zeap.
+[Selected Tome chip]
+┌──────────────────────────────────────────────────────────┐
+│ Ask Sage about this Tome, or type / for Tome skills...   │
+│                                              [+] [model] │
+└──────────────────────────────────────────────────────────┘
+[Sources] [Report] [Quiz] [Flashcards] [Audio] [Chat]
+                 View expanded Tome dashboard →
+```
+
+- **Role:** Calm home base for deliberate Tome work
+- **Content:** Selected Tome context, large composer, capability chips, dashboard affordance
+- **Default:** Opening the app or selecting a Tome lands here
+- **Dashboard:** Secondary overview for freshness/status, reached intentionally
+- **Interaction:** Capability chips route to focused views; composer routes natural language intent
+
+### State 1: Global Command Overlay
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -98,6 +146,7 @@ The floating window is a **card stack**. The input bar is always the bottom laye
 ```
 
 - **Size:** 600px × 48px
+- **Role:** Transient macOS overlay, not the primary in-app home page
 - **Position:** Centered horizontally, **upper third** of screen (~20–25% from top)
 - **Shape:** Full rounded (pill)
 - **Background:** `surface` at 80% opacity + `backdrop-blur: 32px` — slightly lighter than the deepest background to create floating effect
@@ -303,9 +352,11 @@ The floating window is a **card stack**. The input bar is always the bottom laye
 1. **Window position** persists across sessions (user can drag to reposition)
 2. **Going back** collapses the top card (Esc key or back gesture)
 3. **Pin mode** (optional): Click pin icon to keep window visible
-4. **Global hotkey** activates the palette (configurable, default: `Cmd+Shift+S`)
+4. **Global hotkey** activates the command overlay (configurable, default: `Cmd+Shift+S`)
 5. **X button** appears on hover (top-right, like Raycast)
 6. **No window chrome** — no title bar, no system decorations
+7. **Opening the full app** lands on Tome Home, not the compact overlay
+8. **Tome Dashboard** is secondary and reached intentionally from Tome Home
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,7 +4,9 @@
 
 > **For:** Claude Code, Codex, or any coding agent. Follow tasks sequentially. Each task is 2-5 minutes.
 
-> **Read first:** `BRAINSTORM.md`, `DESIGN.md` — full architecture and design spec.
+> **Read first:** `BRAINSTORM.md`, `DESIGN.md`, `docs/PRODUCT_SURFACES.md` — full architecture, design spec, and current product-surface direction.
+
+> **Current direction override:** this Phase 1 plan is historical in places. Current frontend direction is Tome Home as the default in-app surface, Tome Dashboard as secondary, focused skill views for deep work, and a future macOS Spotlight/Raycast-style command overlay. Near-term target is macOS desktop; hosted/web product work is out of scope for now.
 
 ---
 
@@ -29,7 +31,7 @@
 # Backend
 pip install sentence-transformers aiohttp pyyaml
 
-# Frontend  
+# Frontend
 cd frontend && npm install framer-motion zustand clsx tailwind-merge
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,22 @@ Sage is moving toward a NotebookLM-like experience that stays local-first and pr
 - **Tomes**: focused workspaces that isolate source sets and chat history.
 - **Bring your own agent/provider**: local models, Ollama, OpenAI-compatible APIs, Anthropic, DeepSeek, and other providers through a small backend abstraction.
 - **Grounded outputs**: chat, reports, quizzes, flashcards, and audio reviews that cite or otherwise remain tied to the selected sources.
-- **Floating desktop UX**: an Ethereal Console style interface that feels like a lightweight intelligence layer over the OS.
+- **Tome Home default**: a calm, composer-first surface after opening Sage or selecting a Tome.
+- **Floating desktop UX**: a future Spotlight/Raycast-style command bar that feels like a lightweight intelligence layer over macOS.
 
 arXiv support and paper summarization remain useful discovery paths, but they are no longer the center of the product. The main direction is user-owned local knowledge.
+
+The desktop UI has two complementary layers: **Tome Home** for deliberate in-app work, and a future **global command bar** for quick macOS capture/search/skill launch from anywhere. Tome Dashboard remains a secondary overview for artifact status and management, not the default first impression.
+
+Near-term scope is macOS desktop-first. The Next.js frontend can run in a browser for development, but a hosted/user-facing web version is out of scope until the desktop UX, local data model, privacy story, and sync requirements are stable.
 
 ## Current Features
 
 - **Tauri desktop shell** with a Next.js 15 frontend.
 - **FastAPI backend** for knowledge, chat, Tomes, providers, and research discovery endpoints.
 - **Local knowledge store** with document chunks, embeddings, sessions, and Tome/source links.
-- **Floating command UI** with chat, report, quiz, flashcard, audio, history, and Tome-oriented components.
+- **Tome Home** composer-first UI with capability chips for chat, report, quiz, flashcards, audio, history, and Tome-oriented components.
+- **Secondary Tome Dashboard** for artifact/source status and generated work management.
 - **Tailwind v4 design tokens** for the dark Ethereal Console visual system.
 - **pytest backend suite** and GitHub Actions CI.
 
@@ -31,6 +37,7 @@ Several planning/specification files in the repo describe where Sage is headed:
 
 - `BRAINSTORM.md`: product direction from arXiv summarizer to local knowledge agent.
 - `DESIGN.md`: Ethereal Console UI/UX specification.
+- `docs/PRODUCT_SURFACES.md`: current Tome Home, command-bar overlay, desktop/web scope context for humans and agents.
 - `PLAN.md`: implementation plan for the local knowledge agent foundation.
 - `AGENT_SKILL_SPEC.md`: contract between backend skills and frontend UI components.
 - `STITCH_PROMPT.md`: original design prompt/reference for the floating UI.
@@ -133,17 +140,20 @@ Sage/
 │   ├── src/lib/             # Typed API client and frontend utilities
 │   └── src-tauri/           # Tauri desktop configuration
 ├── designs/                 # Design references and generated visual artifacts
+├── docs/                    # Current product-surface notes and feature references
 ├── *.md                     # Product, design, agent, and implementation docs
 └── README.md
 ```
 
 ## Near-Term Roadmap
 
-- Finish replacing old pre-Ethereal UI paths with the Ethereal Console components.
+- Keep Tome Home as the default composer-first app surface and Tome Dashboard as a secondary overview.
+- Design the macOS global command bar as a separate Spotlight/Raycast-style overlay for quick capture, search, and skill launch.
 - Make Tomes first-class across upload, chat, retrieval, history, and generated artifacts.
 - Improve report rendering and exports, likely moving toward an HTML-friendly artifact model.
 - Add explicit schema migrations for existing local Sage databases.
 - Expand evaluation coverage for retrieval quality, grounding, and generated artifact correctness.
+- Defer hosted/web product work until macOS desktop behavior and local data assumptions are stable.
 
 ## Contributing
 

--- a/SESSION_CONTEXT.md
+++ b/SESSION_CONTEXT.md
@@ -6,7 +6,7 @@
 
 ## Project Overview
 
-**Sage** (renamed from "arXivSage") — a local-first desktop knowledge agent. Tauri + Next.js 15 frontend (Tailwind v4), FastAPI backend.
+**Sage** (renamed from "arXivSage") — a local-first desktop knowledge agent. Tauri + Next.js 15 frontend (Tailwind v4), FastAPI backend. Near-term product target is macOS desktop.
 
 **Core concept:** User-uploads sources as the primary workflow (like NotebookLM). arXiv search is a secondary "discover more" feature. "Tomes" = isolated sessions with focused sources, each with their own chat history. Sources can belong to multiple tomes (many-to-many).
 
@@ -18,25 +18,26 @@
 
 ## Design Vision: "The Ethereal Console"
 
-A floating command palette UI (Raycast-style). Core principles:
-- **No 1px solid borders** — boundaries via color shifts + depth
-- **Dark theme only** — rich charcoal palette, never pure `#000`
-- **Floating pill input bar** — centered upper third, 600×48px, `backdrop-blur: 32px`
-- **7 window states** that stack as cards: Compact Input, Chat, Quiz, Flashcards, Audio Player, Report, History
+Current direction is **Tome Home + command overlay**, not “only a floating palette.”
 
-Full spec: `DESIGN.md`
+- **Tome Home**: default in-app surface implemented in `frontend/src/app/page.tsx`; calm, composer-first, selected-Tome aware, with capability chips.
+- **Tome Dashboard**: secondary overview for artifact/source status and generated work management.
+- **Global command bar**: future Spotlight/Raycast-style macOS overlay for quick capture, search, Tome opening, and skill launch from anywhere.
+- **Focused views**: Chat, Quiz, Flashcards, Audio, Report, History, and Tomes/Sources.
+
+Core principles remain: no heavy chrome, dark charcoal palette, depth over hard dividers, and sparse accent use. Full spec: `DESIGN.md`; current product-surface context: `docs/PRODUCT_SURFACES.md`.
 
 ---
 
 ## Component Inventory (15 components)
 
-### ✅ Ethereal Console Components (8) — Production-ready
+### ✅ Ethereal Console Components and Surfaces — Production-ready
 
-All follow `DESIGN.md` glassmorphic spec. Used in `page.tsx`.
+Focused components follow `DESIGN.md` glassmorphic spec. `page.tsx` also owns app-level surfaces: `TomeHome`, `TomeDashboard`, `TopBar`, and `FocusShell`.
 
 | Component | File | Description |
 |-----------|------|-------------|
-| **CommandBar** | `CommandBar.tsx` | Pill input bar (600×48px), sparkle icon, provider badge |
+| **CommandBar** | `CommandBar.tsx` | Pill input bar. Keep for future global overlay / focused command input patterns. |
 | **ChatWidget** | `ChatWidget.tsx` | Chat card with message bubbles, typing indicator, auto-scroll |
 | **QuizWidget** | `QuizWidget.tsx` | Interactive quiz with progress dots, confirm/skip, completion ring |
 | **FlashcardWidget** | `FlashcardWidget.tsx` | 3D flip cards (Framer Motion), shuffle/reset, keyboard nav |
@@ -144,13 +145,15 @@ Full spec written at `AGENT_SKILL_SPEC.md` (632 lines). Covers:
 
 ---
 
-## What's Next (After Legacy Cleanup)
+## What's Next
 
 | Priority | Item |
 |----------|------|
+| 🔴 | **Global command bar overlay** — design macOS Spotlight/Raycast-style layer separately from Tome Home |
 | 🔴 | **AudioPlayerWidget** — needs `audio_url` prop + real `<audio>` element (currently simulated with setInterval) |
 | 🔴 | **ChatWidget** — needs streaming support (SSE/WebSocket, currently static) |
 | 🔴 | **Backend integration** — wire up `/api/agent/chat` → Agent Orchestrator → Skill Registry |
 | 🟡 | **Piper TTS setup** — voice models + pipeline for `generate_audio_review` |
 | 🟡 | **Responsive/viewport testing** |
+| 🟡 | **Web scope** — keep hosted/browser product out of scope; browser mode is for development only |
 | 🟢 | **ComparisonWidget** / **TimelineWidget** — future dedicated components |

--- a/TODO.md
+++ b/TODO.md
@@ -1,64 +1,18 @@
-## Project Setup
+# Sage TODO
 
-- [x] **Initialize FastAPI backend**
-  - Set up Python environment (`venv`) and install FastAPI, Uvicorn[^1]
-  - Create basic "Hello World" API endpoint[^1]
-- [x] **Setup Next.js + Electron frontend**
-  - Initialize Next.js project and Electron integration
-  - Configure Tailwind CSS and chosen component library
+> Historical note: the original TODO predates the local-first Tome direction and referenced Electron/Instagram-style arXiv feeds. Current work should follow `README.md`, `DESIGN.md`, `SESSION_CONTEXT.md`, `AGENT_SKILL_SPEC.md`, and `docs/PRODUCT_SURFACES.md`.
 
-## Backend (FastAPI)
+## Current Frontend/Product TODO
 
-- [x] **Implement arXiv API integration**
-  - Query arXiv for top/latest papers based on keyword input
-- [x] **PDF download \& text extraction**
-  - Download PDFs from arXiv URLs
-  - Extract text from PDFs (e.g., using `pdfplumber` or `PyMuPDF`)
-- [x] **Integrate DeepSeek API for summarization**
-  - Send extracted text to DeepSeek API
-  - Format summaries into short, engaging Instagram-style posts
-- [x] **Create REST endpoints**
-  - Endpoint accepting keyword, returning summarized posts as JSON
-  - Ensure clear data validation with Pydantic models[^2]
+- [x] Make Tome Home the default app landing surface.
+- [x] Preserve Tome Dashboard as a secondary overview.
+- [ ] Design the macOS global command-bar overlay as a separate Spotlight/Raycast-style layer.
+- [ ] Wire the Tome Home composer to the real agent/chat endpoint.
+- [ ] Connect capability chips to real skill execution and generated artifacts.
+- [ ] Keep hosted/web deployment out of scope until desktop scope stabilizes.
+- [ ] Continue replacing or deleting stale pre-Ethereal UI paths.
 
-## Frontend (Next.js + React)
+## Validation
 
-- [x] **Create keyword input/search component**
-  - Handle user input and send requests to FastAPI backend using fetch/Axios[^1]
-- [ ] **Implement React "Post" component**
-  - Display summarized content clearly and attractively
-- [ ] **Build Instagram-like feed page**
-  - Dynamically populate feed with summaries from backend API
-
-## Integration \& Communication
-
-- [ ] **Integrate Next.js frontend with FastAPI backend**
-  - Set up proxy or rewrites in Next.js (`next.config.js`) for seamless communication[^3][^5]
-  - Handle loading states and errors gracefully in UI
-
-## ML Extensions (Future-Proofing)
-
-- [ ] **Set up ML model integration structure in FastAPI**
-  - Use lifespan events to manage ML model lifecycle efficiently[^6]
-  - Prepare structure for future ML model deployment/inference endpoints[^2][^4]
-
-## Electron Packaging \& Deployment
-
-- [ ] **Electron packaging setup**
-  - Configure Electron-builder or Electron-packager for distribution
-
-## Testing \& Documentation
-
-- [ ] **Write tests for FastAPI endpoints**
-  - Unit tests for API logic (arXiv fetching, PDF extraction, summarization)
-- [x] **Write clear documentation**
-  - README with setup instructions, environment variables, and usage examples
-
-<div style="text-align: center">⁂</div>
-
-[^1]: <https://www.restack.io/p/fastapi-answer-nextjs-integration>
-[^2]: <https://github.com/xbeat/Machine-Learning/blob/main/Integrating> ML Models in FastAPI with Python.md
-[^3]: <https://vercel.com/templates/next.js/nextjs-fastapi-starter>
-[^4]: <https://www.evidentlyai.com/blog/fastapi-tutorial>
-[^5]: <https://github.com/psycho-baller/nextjs-and-fastapi-backend>
-[^6]: <https://blog.jetbrains.com/pycharm/2024/09/how-to-use-fastapi-for-machine-learning/>
+- Frontend changes: run `cd frontend && npm run build`.
+- Backend changes: run relevant `uv run --group dev pytest` commands from `backend/`.

--- a/designs/tome-dashboard-proposal.html
+++ b/designs/tome-dashboard-proposal.html
@@ -281,9 +281,20 @@
       user-select: none;
     }
     .card:hover { transform: translateY(-2px); background: color-mix(in srgb, var(--surface-container-high) 76%, transparent); box-shadow: inset 0 0 0 1px rgba(173,198,255,.18), 0 8px 24px rgba(0,0,0,.22); }
-    .card.is-dragging { opacity: .38; transform: scale(.985); }
-    .card.drag-over { box-shadow: inset 0 0 0 1px rgba(173,198,255,.38), 0 0 0 4px rgba(173,198,255,.08); }
+    .card.is-dragging { opacity: .32; transform: scale(.985); }
+    .card.drop-target { box-shadow: inset 0 0 0 1px rgba(173,198,255,.38), 0 0 0 4px rgba(173,198,255,.08); }
     .card.is-resizing { box-shadow: inset 0 0 0 1px rgba(255,183,134,.42), 0 0 0 4px rgba(255,183,134,.08); }
+    .drag-ghost {
+      position: fixed;
+      z-index: 50;
+      pointer-events: none;
+      opacity: .94;
+      transform: translate3d(0,0,0) scale(1.02);
+      box-shadow: 0 22px 70px rgba(0,0,0,.52), 0 0 0 1px rgba(173,198,255,.26), 0 0 80px rgba(173,198,255,.10);
+      filter: saturate(1.08);
+      transition: box-shadow .16s ease, opacity .16s ease;
+    }
+    .grid-settling .card:not(.is-dragging) { will-change: transform; }
     .card.compact .source-list, .card.compact .quote, .card.compact .study-split { display: none; }
     .card.compact .action-row { margin-top: 10px; }
     .card.wide { --col-span: 3; --row-span: 2; }
@@ -471,7 +482,7 @@
 
       <h2>Try the prototype</h2>
       <ul>
-        <li>Drag a card by its handle to rearrange the Dashboard.</li>
+        <li>Drag a card by its handle to rearrange the Dashboard. Nearby cards slide into the available slot as you move.</li>
         <li>Drag the corner grip to resize a card across the responsive grid.</li>
         <li>Click card content to switch focus views.</li>
         <li>Click the compact command bar or press <span class="kbd">⌘</span>/<span class="kbd">Ctrl</span> + <span class="kbd">K</span>.</li>
@@ -522,7 +533,7 @@
 
           <div class="card-grid" id="dashboardGrid">
             <article class="card wide" data-widget="sources" data-focus="sources" tabindex="0" role="button" style="--col-span: 3; --row-span: 3;">
-              <span class="drag-handle" draggable="true" aria-label="Move Sources card">⋮⋮</span>
+              <span class="drag-handle" aria-label="Move Sources card">⋮⋮</span>
               <span class="resize-readout">3×3</span>
               <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Grounding</small><h3>Sources</h3></div><span class="badge good">Current</span></div>
@@ -536,7 +547,7 @@
             </article>
 
             <article class="card" data-widget="chat" data-focus="chat" tabindex="0" role="button" style="--col-span: 1; --row-span: 2;">
-              <span class="drag-handle" draggable="true" aria-label="Move Chat card">⋮⋮</span>
+              <span class="drag-handle" aria-label="Move Chat card">⋮⋮</span>
               <span class="resize-readout">1×2</span>
               <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Recent thread</small><h3>Chat</h3></div><span class="badge">Resume</span></div>
@@ -546,7 +557,7 @@
             </article>
 
             <article class="card" data-widget="report" data-focus="report" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
-              <span class="drag-handle" draggable="true" aria-label="Move Report card">⋮⋮</span>
+              <span class="drag-handle" aria-label="Move Report card">⋮⋮</span>
               <span class="resize-readout">2×2</span>
               <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Synthesis artifact</small><h3>Report</h3></div><span class="badge warn">Stale</span></div>
@@ -555,7 +566,7 @@
             </article>
 
             <article class="card" data-widget="quiz" data-focus="quiz" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
-              <span class="drag-handle" draggable="true" aria-label="Move Quiz card">⋮⋮</span>
+              <span class="drag-handle" aria-label="Move Quiz card">⋮⋮</span>
               <span class="resize-readout">2×2</span>
               <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Study loop</small><h3>Quiz</h3></div><span class="badge">82% last score</span></div>
@@ -565,7 +576,7 @@
             </article>
 
             <article class="card" data-widget="flashcards" data-focus="flashcards" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
-              <span class="drag-handle" draggable="true" aria-label="Move Flashcards card">⋮⋮</span>
+              <span class="drag-handle" aria-label="Move Flashcards card">⋮⋮</span>
               <span class="resize-readout">2×2</span>
               <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Review deck</small><h3>Flashcards</h3></div><span class="badge good">38 cards</span></div>
@@ -577,7 +588,7 @@
             </article>
 
             <article class="card" data-widget="audio" data-focus="audio" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
-              <span class="drag-handle" draggable="true" aria-label="Move Audio card">⋮⋮</span>
+              <span class="drag-handle" aria-label="Move Audio card">⋮⋮</span>
               <span class="resize-readout">2×2</span>
               <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Listen mode</small><h3>Audio Review</h3></div><span class="badge warn">Missing</span></div>
@@ -687,9 +698,11 @@
 
     const grid = document.getElementById('dashboardGrid');
     const resetLayout = document.getElementById('resetLayout');
-    const layoutKey = 'sage-dashboard-layout-v2';
-    let draggedCard = null;
+    const layoutKey = 'sage-dashboard-layout-v3';
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     let resizing = null;
+    let dragState = null;
+    let suppressClick = false;
 
     const defaults = Array.from(grid.querySelectorAll('.card')).map(card => ({
       id: card.dataset.widget,
@@ -726,15 +739,151 @@
       });
     }
 
+    function animateLayout(mutator) {
+      if (reduceMotion) {
+        mutator();
+        return;
+      }
+      const cards = Array.from(grid.querySelectorAll('.card'));
+      const first = new Map(cards.map(card => [card, card.getBoundingClientRect()]));
+      mutator();
+      grid.classList.add('grid-settling');
+      cards.forEach(card => {
+        if (dragState && card === dragState.card) return;
+        const before = first.get(card);
+        const after = card.getBoundingClientRect();
+        const dx = before.left - after.left;
+        const dy = before.top - after.top;
+        if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
+        card.animate([
+          { transform: `translate(${dx}px, ${dy}px)` },
+          { transform: 'translate(0, 0)' }
+        ], {
+          duration: 260,
+          easing: 'cubic-bezier(.2,.8,.2,1)',
+        });
+      });
+      window.setTimeout(() => grid.classList.remove('grid-settling'), 280);
+    }
+
     function resetLayoutToDefault() {
       localStorage.removeItem(layoutKey);
-      defaults.forEach(item => {
-        const card = grid.querySelector(`[data-widget="${item.id}"]`);
-        card.style.setProperty('--col-span', item.col);
-        card.style.setProperty('--row-span', item.row);
-        grid.appendChild(card);
-        updateCardChrome(card);
+      animateLayout(() => {
+        defaults.forEach(item => {
+          const card = grid.querySelector(`[data-widget="${item.id}"]`);
+          card.style.setProperty('--col-span', item.col);
+          card.style.setProperty('--row-span', item.row);
+          grid.appendChild(card);
+          updateCardChrome(card);
+        });
       });
+    }
+
+    function createGhost(card, rect) {
+      const ghost = card.cloneNode(true);
+      ghost.classList.add('drag-ghost');
+      ghost.classList.remove('is-dragging', 'drop-target');
+      ghost.removeAttribute('id');
+      ghost.style.width = `${rect.width}px`;
+      ghost.style.height = `${rect.height}px`;
+      ghost.style.left = `${rect.left}px`;
+      ghost.style.top = `${rect.top}px`;
+      ghost.style.gridColumn = 'auto';
+      ghost.style.gridRow = 'auto';
+      document.body.appendChild(ghost);
+      return ghost;
+    }
+
+    function moveGhost(x, y) {
+      if (!dragState) return;
+      dragState.ghost.style.left = `${x - dragState.offsetX}px`;
+      dragState.ghost.style.top = `${y - dragState.offsetY}px`;
+    }
+
+    function nearestCard(x, y) {
+      const candidates = Array.from(grid.querySelectorAll('.card')).filter(card => card !== dragState.card);
+      let best = null;
+      let bestScore = Infinity;
+      candidates.forEach(card => {
+        const rect = card.getBoundingClientRect();
+        const inside = x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+        const cx = rect.left + rect.width / 2;
+        const cy = rect.top + rect.height / 2;
+        const score = Math.hypot(x - cx, y - cy) - (inside ? 1000 : 0);
+        if (score < bestScore) {
+          bestScore = score;
+          best = card;
+        }
+      });
+      return best;
+    }
+
+    function reorderAround(target, x) {
+      if (!target || !dragState || target === dragState.card || target === dragState.lastTarget) return;
+      const cards = Array.from(grid.querySelectorAll('.card'));
+      const from = cards.indexOf(dragState.card);
+      const to = cards.indexOf(target);
+      const targetRect = target.getBoundingClientRect();
+      const afterTarget = x > targetRect.left + targetRect.width / 2;
+      dragState.lastTarget = target;
+      grid.querySelectorAll('.drop-target').forEach(el => el.classList.remove('drop-target'));
+      target.classList.add('drop-target');
+      animateLayout(() => {
+        if (afterTarget) {
+          grid.insertBefore(dragState.card, target.nextSibling);
+        } else {
+          grid.insertBefore(dragState.card, target);
+        }
+      });
+    }
+
+    function startCardDrag(card, handle, e) {
+      if (resizing || window.innerWidth <= 720) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const rect = card.getBoundingClientRect();
+      dragState = {
+        card,
+        handle,
+        ghost: createGhost(card, rect),
+        offsetX: e.clientX - rect.left,
+        offsetY: e.clientY - rect.top,
+        startX: e.clientX,
+        startY: e.clientY,
+        lastTarget: null,
+        moved: false,
+      };
+      card.classList.add('is-dragging');
+      handle.setPointerCapture(e.pointerId);
+      moveGhost(e.clientX, e.clientY);
+    }
+
+    function moveCardDrag(e) {
+      if (!dragState) return;
+      const distance = Math.hypot(e.clientX - dragState.startX, e.clientY - dragState.startY);
+      dragState.moved = dragState.moved || distance > 4;
+      moveGhost(e.clientX, e.clientY);
+      const target = nearestCard(e.clientX, e.clientY);
+      reorderAround(target, e.clientX);
+    }
+
+    function endCardDrag() {
+      if (!dragState) return;
+      const { card, ghost, moved } = dragState;
+      grid.querySelectorAll('.drop-target').forEach(el => el.classList.remove('drop-target'));
+      const finalRect = card.getBoundingClientRect();
+      ghost.animate([
+        { left: ghost.style.left, top: ghost.style.top, opacity: .94, transform: 'scale(1.02)' },
+        { left: `${finalRect.left}px`, top: `${finalRect.top}px`, opacity: .18, transform: 'scale(.99)' }
+      ], {
+        duration: reduceMotion ? 1 : 180,
+        easing: 'cubic-bezier(.2,.8,.2,1)',
+      }).finished.finally(() => ghost.remove());
+      card.classList.remove('is-dragging');
+      saveLayout();
+      suppressClick = moved;
+      window.setTimeout(() => { suppressClick = false; }, 60);
+      dragState = null;
     }
 
     grid.querySelectorAll('.card').forEach(card => {
@@ -742,41 +891,14 @@
       const grip = card.querySelector('.resize-grip');
 
       card.addEventListener('click', (e) => {
-        if (e.target.closest('.drag-handle, .resize-grip, .ghost-action')) return;
+        if (suppressClick || e.target.closest('.drag-handle, .resize-grip, .ghost-action')) return;
         showFocus(card.dataset.focus);
       });
       card.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') showFocus(card.dataset.focus);
       });
 
-      handle.addEventListener('dragstart', (e) => {
-        draggedCard = card;
-        card.classList.add('is-dragging');
-        e.dataTransfer.effectAllowed = 'move';
-        e.dataTransfer.setData('text/plain', card.dataset.widget);
-      });
-      handle.addEventListener('dragend', () => {
-        card.classList.remove('is-dragging');
-        grid.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
-        draggedCard = null;
-        saveLayout();
-      });
-      card.addEventListener('dragover', (e) => {
-        if (!draggedCard || draggedCard === card) return;
-        e.preventDefault();
-        card.classList.add('drag-over');
-      });
-      card.addEventListener('dragleave', () => card.classList.remove('drag-over'));
-      card.addEventListener('drop', (e) => {
-        e.preventDefault();
-        card.classList.remove('drag-over');
-        if (!draggedCard || draggedCard === card) return;
-        const cards = Array.from(grid.querySelectorAll('.card'));
-        const from = cards.indexOf(draggedCard);
-        const to = cards.indexOf(card);
-        grid.insertBefore(draggedCard, from < to ? card.nextSibling : card);
-        saveLayout();
-      });
+      handle.addEventListener('pointerdown', (e) => startCardDrag(card, handle, e));
 
       grip.addEventListener('pointerdown', (e) => {
         e.preventDefault();
@@ -797,17 +919,21 @@
     });
 
     document.addEventListener('pointermove', (e) => {
+      if (dragState) moveCardDrag(e);
       if (!resizing) return;
       const dx = Math.round((e.clientX - resizing.startX) / Math.max(resizing.cellW, 80));
       const dy = Math.round((e.clientY - resizing.startY) / Math.max(resizing.cellH, 80));
       const nextCol = Math.max(1, Math.min(4, resizing.startCol + dx));
       const nextRow = Math.max(1, Math.min(4, resizing.startRow + dy));
-      resizing.card.style.setProperty('--col-span', nextCol);
-      resizing.card.style.setProperty('--row-span', nextRow);
-      updateCardChrome(resizing.card);
+      animateLayout(() => {
+        resizing.card.style.setProperty('--col-span', nextCol);
+        resizing.card.style.setProperty('--row-span', nextRow);
+        updateCardChrome(resizing.card);
+      });
     });
 
     document.addEventListener('pointerup', () => {
+      if (dragState) endCardDrag();
       if (!resizing) return;
       resizing.card.classList.remove('is-resizing');
       saveLayout();

--- a/designs/tome-dashboard-proposal.html
+++ b/designs/tome-dashboard-proposal.html
@@ -1,0 +1,617 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sage Tome Dashboard Proposal</title>
+  <style>
+    :root {
+      --surface-container-lowest: #0e0e0e;
+      --surface-container-low: #1c1b1b;
+      --surface: #131313;
+      --surface-container: #201f1f;
+      --surface-container-high: #2a2a2a;
+      --surface-container-highest: #353534;
+      --surface-bright: #3a3939;
+      --primary: #adc6ff;
+      --primary-container: #4d8eff;
+      --on-primary: #002e6a;
+      --on-surface: #e5e2e1;
+      --on-surface-variant: #c2c6d6;
+      --outline: #8c909f;
+      --outline-variant: #424754;
+      --tertiary: #ffb786;
+      --success: #9bd67f;
+      --warn: #ffd073;
+      --danger: #ffb4ab;
+      --radius-sm: 8px;
+      --radius-md: 16px;
+      --radius-lg: 32px;
+      --shadow: 0 8px 32px rgba(0,0,0,.42), 0 0 60px rgba(173,198,255,.04);
+      --font: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    html { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--on-surface);
+      background:
+        radial-gradient(900px 260px at 50% 4%, rgba(173,198,255,.10), transparent 62%),
+        radial-gradient(620px 320px at 15% 35%, rgba(255,183,134,.04), transparent 72%),
+        var(--surface-container-lowest);
+      font-family: var(--font);
+      -webkit-font-smoothing: antialiased;
+      line-height: 1.5;
+    }
+
+    button, input { font: inherit; }
+    button { cursor: pointer; }
+    .shell {
+      display: grid;
+      grid-template-columns: 360px minmax(760px, 1fr);
+      gap: 24px;
+      width: min(1480px, calc(100vw - 48px));
+      margin: 0 auto;
+      padding: 28px 0 48px;
+    }
+
+    .proposal {
+      position: sticky;
+      top: 24px;
+      height: calc(100vh - 48px);
+      overflow: auto;
+      padding: 22px;
+      border-radius: 28px;
+      background: color-mix(in srgb, var(--surface) 82%, transparent);
+      box-shadow: var(--shadow);
+      border: 1px solid rgba(66,71,84,.15);
+      backdrop-filter: blur(32px);
+    }
+    .proposal h1 {
+      margin: 0 0 8px;
+      font-size: 28px;
+      letter-spacing: -.04em;
+      line-height: 1.05;
+    }
+    .proposal h2 {
+      margin: 26px 0 8px;
+      font-size: 13px;
+      text-transform: uppercase;
+      color: var(--primary);
+      letter-spacing: .11em;
+    }
+    .proposal p, .proposal li {
+      color: rgba(194,198,214,.82);
+      font-size: 14px;
+    }
+    .proposal ul { padding-left: 18px; margin: 8px 0 0; }
+    .tagline {
+      font-size: 15px;
+      color: var(--on-surface-variant);
+      margin: 0 0 18px;
+    }
+    .principle {
+      background: rgba(173,198,255,.08);
+      border: 1px solid rgba(173,198,255,.16);
+      border-radius: 18px;
+      padding: 14px;
+      color: var(--on-surface);
+      margin: 14px 0;
+    }
+    .kbd {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 22px;
+      height: 22px;
+      padding: 0 7px;
+      border-radius: 7px;
+      background: var(--surface-container-high);
+      color: var(--on-surface);
+      font-size: 12px;
+      box-shadow: inset 0 0 0 1px rgba(140,144,159,.18);
+    }
+
+    .stage {
+      position: relative;
+      min-height: calc(100vh - 56px);
+      border-radius: 34px;
+      background:
+        radial-gradient(550px 180px at 50% 0%, rgba(173,198,255,.07), transparent 70%),
+        linear-gradient(180deg, rgba(19,19,19,.86), rgba(14,14,14,.96));
+      box-shadow: var(--shadow);
+      border: 1px solid rgba(66,71,84,.13);
+      overflow: hidden;
+    }
+    .stage::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background-image:
+        linear-gradient(rgba(255,255,255,.018) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,.014) 1px, transparent 1px);
+      background-size: 48px 48px;
+      mask-image: radial-gradient(circle at 50% 20%, black, transparent 72%);
+    }
+
+    .top-strip {
+      position: relative;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 18px 22px 4px;
+      color: rgba(194,198,214,.58);
+      font-size: 12px;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+    }
+    .status-dot { width: 7px; height: 7px; border-radius: 999px; background: var(--success); display: inline-block; margin-right: 8px; box-shadow: 0 0 12px rgba(155,214,127,.45); }
+
+    .prototype {
+      position: relative;
+      z-index: 2;
+      width: min(960px, calc(100% - 48px));
+      margin: 18px auto 36px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 18px;
+    }
+
+    .command-mini {
+      width: min(600px, 100%);
+      height: 48px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 0 15px 0 16px;
+      background: rgba(19,19,19,.82);
+      border-radius: 999px;
+      border: 1px solid rgba(66,71,84,.20);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(32px);
+      transition: border-color .18s, transform .18s, background .18s;
+    }
+    .command-mini:hover { border-color: rgba(173,198,255,.28); transform: translateY(-1px); background: rgba(19,19,19,.92); }
+    .sparkle { color: var(--primary); font-size: 18px; }
+    .command-placeholder { flex: 1; color: rgba(194,198,214,.58); font-size: 14px; }
+    .provider {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      height: 24px;
+      padding: 0 10px;
+      border-radius: 999px;
+      background: var(--surface-container-high);
+      color: var(--on-surface-variant);
+      font-size: 11px;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+      box-shadow: inset 0 0 0 1px rgba(66,71,84,.20);
+    }
+
+    .dashboard {
+      width: min(900px, 100%);
+      border-radius: 28px;
+      background: rgba(19,19,19,.82);
+      border: 1px solid rgba(66,71,84,.18);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(32px);
+      overflow: hidden;
+      animation: floatIn .42s cubic-bezier(.25,.46,.45,.94) both;
+    }
+    @keyframes floatIn { from { opacity: 0; transform: translateY(14px) scale(.98); } to { opacity: 1; transform: translateY(0) scale(1); } }
+
+    .dash-hero {
+      padding: 24px;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 18px;
+      background: linear-gradient(180deg, rgba(32,31,31,.94), rgba(19,19,19,.52));
+    }
+    .crumb { color: rgba(194,198,214,.55); font-size: 12px; text-transform: uppercase; letter-spacing: .09em; margin-bottom: 6px; }
+    .dash-title { margin: 0; font-size: 28px; line-height: 1.1; letter-spacing: -.035em; }
+    .dash-sub { margin: 8px 0 0; color: rgba(194,198,214,.78); font-size: 14px; max-width: 560px; }
+    .hero-actions { display: flex; gap: 8px; align-items: start; flex-wrap: wrap; justify-content: end; }
+    .pill-btn {
+      min-height: 34px;
+      padding: 0 13px;
+      border-radius: 999px;
+      border: 1px solid rgba(66,71,84,.20);
+      background: rgba(42,42,42,.70);
+      color: var(--on-surface-variant);
+      transition: transform .14s, background .14s, border-color .14s, color .14s;
+    }
+    .pill-btn:hover, .pill-btn.active { transform: translateY(-1px); background: rgba(173,198,255,.12); border-color: rgba(173,198,255,.24); color: var(--primary); }
+    .pill-btn.primary { background: rgba(173,198,255,.13); color: var(--primary); border-color: rgba(173,198,255,.24); }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+      padding: 0 24px 20px;
+    }
+    .metric {
+      padding: 12px;
+      border-radius: 16px;
+      background: rgba(28,27,27,.72);
+      box-shadow: inset 0 0 0 1px rgba(66,71,84,.10);
+    }
+    .metric strong { display: block; font-size: 20px; letter-spacing: -.02em; }
+    .metric span { color: rgba(194,198,214,.58); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+
+    .card-grid {
+      display: grid;
+      grid-template-columns: 1.15fr .85fr;
+      gap: 12px;
+      padding: 0 18px 18px;
+    }
+    .card {
+      min-height: 154px;
+      padding: 17px;
+      border: 0;
+      border-radius: 22px;
+      background: color-mix(in srgb, var(--surface-container) 78%, transparent);
+      box-shadow: inset 0 0 0 1px rgba(66,71,84,.12);
+      color: var(--on-surface);
+      text-align: left;
+      transition: transform .16s, background .16s, box-shadow .16s;
+      position: relative;
+      overflow: hidden;
+    }
+    .card:hover { transform: translateY(-2px); background: color-mix(in srgb, var(--surface-container-high) 76%, transparent); box-shadow: inset 0 0 0 1px rgba(173,198,255,.18), 0 8px 24px rgba(0,0,0,.22); }
+    .wide { grid-column: span 1; min-height: 202px; }
+    .card-head { display: flex; justify-content: space-between; align-items: start; gap: 10px; margin-bottom: 12px; }
+    .card h3 { margin: 0; font-size: 16px; letter-spacing: -.015em; }
+    .card small { color: rgba(194,198,214,.55); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      height: 24px;
+      padding: 0 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      color: var(--primary);
+      background: rgba(173,198,255,.10);
+      box-shadow: inset 0 0 0 1px rgba(173,198,255,.14);
+      white-space: nowrap;
+    }
+    .badge.warn { color: var(--warn); background: rgba(255,208,115,.10); box-shadow: inset 0 0 0 1px rgba(255,208,115,.14); }
+    .badge.good { color: var(--success); background: rgba(155,214,127,.10); box-shadow: inset 0 0 0 1px rgba(155,214,127,.14); }
+    .card p { margin: 0; color: rgba(194,198,214,.74); font-size: 13px; }
+    .action-row { display: flex; gap: 8px; margin-top: 14px; flex-wrap: wrap; }
+    .ghost-action {
+      height: 30px;
+      padding: 0 10px;
+      border-radius: 999px;
+      border: 0;
+      background: rgba(53,53,52,.56);
+      color: rgba(229,226,225,.86);
+      font-size: 12px;
+      transition: background .16s, color .16s;
+    }
+    .ghost-action:hover { background: rgba(173,198,255,.14); color: var(--primary); }
+    .source-list { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+    .source-item { display: flex; align-items: center; gap: 9px; color: rgba(229,226,225,.90); font-size: 13px; }
+    .source-icon { width: 28px; height: 28px; border-radius: 9px; display: grid; place-items: center; background: rgba(173,198,255,.10); color: var(--primary); }
+    .mini-report { padding: 12px; border-radius: 16px; background: rgba(14,14,14,.32); color: rgba(229,226,225,.90); font-size: 13px; }
+    .quote { border-left: 0; margin-top: 10px; color: rgba(194,198,214,.72); font-size: 13px; }
+    .progress { height: 7px; border-radius: 999px; background: rgba(66,71,84,.28); overflow: hidden; margin: 14px 0 8px; }
+    .progress > span { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, var(--primary), var(--tertiary)); }
+    .study-split { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 10px; }
+    .study-box { padding: 12px; border-radius: 16px; background: rgba(14,14,14,.28); }
+    .study-box strong { display: block; font-size: 20px; }
+    .study-box span { color: rgba(194,198,214,.58); font-size: 12px; }
+
+    .focus-panel {
+      display: none;
+      width: min(760px, 100%);
+      border-radius: 28px;
+      background: rgba(19,19,19,.90);
+      border: 1px solid rgba(66,71,84,.18);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(32px);
+      overflow: hidden;
+      animation: floatIn .34s cubic-bezier(.25,.46,.45,.94) both;
+    }
+    .focus-panel.visible { display: block; }
+    .focus-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 18px 20px; background: rgba(32,31,31,.75); }
+    .focus-header h2 { margin: 0; font-size: 20px; letter-spacing: -.025em; }
+    .focus-body { padding: 20px; }
+    .report-body h3 { margin: 0 0 8px; font-size: 18px; }
+    .report-body p { color: rgba(194,198,214,.78); font-size: 14px; }
+    .table { width: 100%; border-collapse: collapse; margin-top: 14px; border-radius: 14px; overflow: hidden; background: rgba(14,14,14,.28); }
+    .table th, .table td { padding: 10px; text-align: left; font-size: 13px; }
+    .table th { color: var(--primary); background: rgba(173,198,255,.07); font-weight: 600; }
+    .table td { color: rgba(229,226,225,.82); }
+    .option { padding: 13px; border-radius: 15px; background: rgba(32,31,31,.76); margin: 9px 0; color: rgba(229,226,225,.85); box-shadow: inset 0 0 0 1px rgba(66,71,84,.14); }
+    .option.selected { box-shadow: inset 0 0 0 1px rgba(173,198,255,.30); background: rgba(173,198,255,.10); color: var(--primary); }
+    .audio-controls { display: flex; align-items: center; justify-content: center; gap: 14px; margin: 20px 0; }
+    .round { width: 46px; height: 46px; border-radius: 999px; border: 0; background: var(--primary); color: var(--on-primary); font-weight: 800; }
+    .transcript { max-height: 160px; overflow: auto; padding: 14px; border-radius: 16px; background: rgba(14,14,14,.28); color: rgba(194,198,214,.74); font-size: 13px; }
+
+    .command-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 20;
+      display: none;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: min(14vh, 120px);
+      background: rgba(0,0,0,.38);
+      backdrop-filter: blur(10px);
+    }
+    .command-overlay.visible { display: flex; animation: fade .18s both; }
+    @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+    .spotlight {
+      width: min(680px, calc(100vw - 32px));
+      border-radius: 26px;
+      background: rgba(19,19,19,.94);
+      border: 1px solid rgba(173,198,255,.20);
+      box-shadow: 0 24px 80px rgba(0,0,0,.65), 0 0 80px rgba(173,198,255,.08);
+      overflow: hidden;
+      animation: spotlightIn .2s cubic-bezier(.25,.46,.45,.94) both;
+    }
+    @keyframes spotlightIn { from { transform: translateY(-12px) scale(.98); opacity: .7; } to { transform: translateY(0) scale(1); opacity: 1; } }
+    .spot-input { height: 58px; display: flex; align-items: center; gap: 13px; padding: 0 18px; }
+    .spot-input input { flex: 1; height: 100%; background: transparent; border: 0; outline: 0; color: var(--on-surface); font-size: 17px; }
+    .spot-list { padding: 8px; border-top: 1px solid rgba(66,71,84,.16); }
+    .spot-row { display: grid; grid-template-columns: 34px 1fr auto; gap: 12px; align-items: center; padding: 10px; border-radius: 15px; color: rgba(229,226,225,.88); }
+    .spot-row:hover, .spot-row.active { background: rgba(173,198,255,.10); color: var(--primary); }
+    .spot-row span:nth-child(2) small { display: block; color: rgba(194,198,214,.55); font-size: 12px; margin-top: 1px; }
+    .hint { color: rgba(194,198,214,.48); font-size: 12px; }
+
+    .mobile-note { display: none; }
+    @media (max-width: 1080px) {
+      .shell { grid-template-columns: 1fr; width: min(960px, calc(100vw - 32px)); }
+      .proposal { position: relative; height: auto; top: 0; }
+      .stage { min-height: auto; }
+    }
+    @media (max-width: 720px) {
+      .metrics { grid-template-columns: repeat(2, 1fr); }
+      .card-grid { grid-template-columns: 1fr; }
+      .dash-hero { grid-template-columns: 1fr; }
+      .hero-actions { justify-content: start; }
+      .provider { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <aside class="proposal">
+      <h1>Dashboard as default, command bar as summonable power tool</h1>
+      <p class="tagline">Proposal for Sage's Tome-centric interaction model.</p>
+
+      <div class="principle">
+        <strong>Great Sage thesis:</strong> the Dashboard handles common intent. The floating command bar handles expressive intent. Focus views handle deep work.
+      </div>
+
+      <h2>Answer to the command bar question</h2>
+      <p>Yes, the command bar becomes secondary in the default flow, but not less important. It should function like macOS Spotlight or Raycast: summonable with a key command, always Tome-aware, and optimized for actions that are too specific for fixed buttons.</p>
+      <p>In normal use, the selected Tome opens to Dashboard. Press <span class="kbd">⌘</span> <span class="kbd">K</span> or click the small bar to invoke natural language and command search.</p>
+
+      <h2>Three-layer model</h2>
+      <ul>
+        <li><strong>TomeSelector:</strong> choose the knowledge scope.</li>
+        <li><strong>Dashboard:</strong> glanceable, directly clickable overview of all common Tome workflows.</li>
+        <li><strong>Focus view:</strong> one expanded component for chat, report, quiz, flashcards, audio, or sources.</li>
+      </ul>
+
+      <h2>Dashboard job</h2>
+      <p>Dashboard should not auto-generate everything. It should show what exists, what is missing, what is stale, and what can be opened or generated with one click.</p>
+
+      <h2>Command bar job</h2>
+      <p>The command bar should answer questions like: “make this quiz harder,” “compare the latest report with source 3,” “generate a skeptical panel discussion,” or “find contradictions across these papers.”</p>
+
+      <h2>Try the prototype</h2>
+      <ul>
+        <li>Click Dashboard cards to switch focus views.</li>
+        <li>Click the compact command bar or press <span class="kbd">⌘</span>/<span class="kbd">Ctrl</span> + <span class="kbd">K</span>.</li>
+        <li>Use the quick-action pills to see how common actions stay visible without natural language.</li>
+      </ul>
+    </aside>
+
+    <main class="stage">
+      <div class="top-strip">
+        <span><span class="status-dot"></span>Tome active</span>
+        <span>Dashboard mode · command bar available</span>
+      </div>
+
+      <section class="prototype">
+        <button class="command-mini" id="openCommand" aria-label="Open command bar">
+          <span class="sparkle">✦</span>
+          <span class="command-placeholder">Ask or command within “Weak Measurement in BECs”...</span>
+          <span class="provider">⚡ GPT-4o</span>
+          <span class="hint">⌘K</span>
+        </button>
+
+        <section class="dashboard" id="dashboard">
+          <div class="dash-hero">
+            <div>
+              <div class="crumb">Tome Dashboard</div>
+              <h1 class="dash-title">Weak Measurement in BECs</h1>
+              <p class="dash-sub">A focused workspace for stochastic Gross-Pitaevskii dynamics, TSSP methods, and weak-measurement models. Dashboard is the default view. Natural language is optional, not mandatory.</p>
+            </div>
+            <div class="hero-actions">
+              <button class="pill-btn primary" data-focus="chat">Ask</button>
+              <button class="pill-btn" data-focus="report">Report</button>
+              <button class="pill-btn" data-focus="quiz">Quiz</button>
+              <button class="pill-btn" data-focus="audio">Audio</button>
+            </div>
+          </div>
+
+          <div class="metrics">
+            <div class="metric"><strong>12</strong><span>sources</span></div>
+            <div class="metric"><strong>884</strong><span>chunks</span></div>
+            <div class="metric"><strong>4</strong><span>sessions</span></div>
+            <div class="metric"><strong>3</strong><span>stale artifacts</span></div>
+          </div>
+
+          <div class="card-grid">
+            <button class="card wide" data-focus="sources">
+              <div class="card-head"><div><small>Grounding</small><h3>Sources</h3></div><span class="badge good">Current</span></div>
+              <p>12 documents are active in this Tome. New source additions should mark report, quiz, and audio as stale until regenerated.</p>
+              <div class="source-list">
+                <div class="source-item"><span class="source-icon">pdf</span> Stochastic projected Gross-Pitaevskii equation review</div>
+                <div class="source-item"><span class="source-icon">md</span> TSSP weak measurement notes</div>
+                <div class="source-item"><span class="source-icon">url</span> Numerical methods comparison</div>
+              </div>
+              <div class="action-row"><span class="ghost-action">Manage sources</span><span class="ghost-action">Upload</span></div>
+            </button>
+
+            <button class="card" data-focus="chat">
+              <div class="card-head"><div><small>Recent thread</small><h3>Chat</h3></div><span class="badge">Resume</span></div>
+              <p>Last question: “How does weak measurement change the stochastic noise term?”</p>
+              <p class="quote">Answer preview: measurement backaction appears as a conditioned update...</p>
+              <div class="action-row"><span class="ghost-action">Continue</span></div>
+            </button>
+
+            <button class="card" data-focus="report">
+              <div class="card-head"><div><small>Synthesis artifact</small><h3>Report</h3></div><span class="badge warn">Stale</span></div>
+              <div class="mini-report">Latest report covers 9/12 current sources. HTML-first export could preserve tables, citations, and layout better than Markdown alone.</div>
+              <div class="action-row"><span class="ghost-action">Open</span><span class="ghost-action">Regenerate</span><span class="ghost-action">Export</span></div>
+            </button>
+
+            <button class="card" data-focus="quiz">
+              <div class="card-head"><div><small>Study loop</small><h3>Quiz</h3></div><span class="badge">82% last score</span></div>
+              <p>Five-question check generated from core source chunks. Three new sources were added since the last run.</p>
+              <div class="progress"><span style="width:82%"></span></div>
+              <div class="action-row"><span class="ghost-action">Start quiz</span><span class="ghost-action">Regenerate harder</span></div>
+            </button>
+
+            <button class="card" data-focus="flashcards">
+              <div class="card-head"><div><small>Review deck</small><h3>Flashcards</h3></div><span class="badge good">38 cards</span></div>
+              <div class="study-split">
+                <div class="study-box"><strong>14</strong><span>due today</span></div>
+                <div class="study-box"><strong>6</strong><span>need source refresh</span></div>
+              </div>
+              <div class="action-row"><span class="ghost-action">Review</span><span class="ghost-action">Add from new sources</span></div>
+            </button>
+
+            <button class="card" data-focus="audio">
+              <div class="card-head"><div><small>Listen mode</small><h3>Audio Review</h3></div><span class="badge warn">Missing</span></div>
+              <p>No audio review exists for the current source set. Future option: single narrator, two-person explainer, or panel discussion.</p>
+              <div class="action-row"><span class="ghost-action">Generate audio</span><span class="ghost-action">Panel mode later</span></div>
+            </button>
+          </div>
+        </section>
+
+        <section class="focus-panel" id="focusPanel" aria-live="polite">
+          <div class="focus-header">
+            <h2 id="focusTitle">Focused View</h2>
+            <button class="pill-btn" id="backDashboard">← Dashboard</button>
+          </div>
+          <div class="focus-body" id="focusBody"></div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <div class="command-overlay" id="commandOverlay" role="dialog" aria-modal="true" aria-label="Command bar">
+    <div class="spotlight">
+      <div class="spot-input">
+        <span class="sparkle">✦</span>
+        <input id="spotInput" value="" placeholder="Ask, search, or run a Tome action..." />
+        <span class="hint">Esc</span>
+      </div>
+      <div class="spot-list">
+        <div class="spot-row active" data-focus="report"><span>⌘</span><span>Regenerate stale report<small>Uses all 12 current sources in this Tome</small></span><span class="hint">Enter</span></div>
+        <div class="spot-row" data-focus="quiz"><span>?</span><span>Make a harder quiz<small>Five questions, higher difficulty, cite source chunks</small></span><span></span></div>
+        <div class="spot-row" data-focus="audio"><span>♪</span><span>Draft a two-person audio review<small>Experimental command, still grounded in Tome sources</small></span><span></span></div>
+        <div class="spot-row" data-focus="sources"><span>＋</span><span>Upload new source<small>Attach a PDF, Markdown note, or pasted text</small></span><span></span></div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const dashboard = document.getElementById('dashboard');
+    const focusPanel = document.getElementById('focusPanel');
+    const focusTitle = document.getElementById('focusTitle');
+    const focusBody = document.getElementById('focusBody');
+    const overlay = document.getElementById('commandOverlay');
+    const spotInput = document.getElementById('spotInput');
+
+    const views = {
+      sources: {
+        title: 'Sources Focus View',
+        body: `<p>This is where the full source manager would live. Dashboard showed the source summary, but focus mode is for upload, delete, tome assignment, and source inspection.</p>
+        <div class="source-list">
+          <div class="source-item"><span class="source-icon">pdf</span> SPGPE review · 142 chunks · included in report</div>
+          <div class="source-item"><span class="source-icon">md</span> TSSP notes · 63 chunks · added after latest quiz</div>
+          <div class="source-item"><span class="source-icon">url</span> Numerical methods comparison · 41 chunks · not yet in audio</div>
+        </div>
+        <div class="action-row"><button class="ghost-action">Upload source</button><button class="ghost-action">Re-index Tome</button></div>`
+      },
+      chat: {
+        title: 'Chat Focus View',
+        body: `<p><strong>User:</strong> How does weak measurement change the stochastic noise term?</p>
+        <p><strong>Sage:</strong> In a conditioned evolution, the measurement record updates the state estimate, while backaction modifies the stochastic term. The dashboard keeps this thread resumable without requiring the user to retype context.</p>
+        <div class="action-row"><button class="ghost-action">Ask follow-up</button><button class="ghost-action">Turn answer into flashcards</button></div>`
+      },
+      report: {
+        title: 'Report Focus View',
+        body: `<div class="report-body"><h3>Weak Measurement and sGPE Dynamics</h3>
+        <p>The focused report view can be a full reading surface with table rendering, source anchors, export controls, and eventually an HTML-first artifact mode.</p>
+        <table class="table"><thead><tr><th>Artifact</th><th>Source coverage</th><th>Status</th></tr></thead><tbody><tr><td>Report</td><td>9 / 12 sources</td><td>Stale</td></tr><tr><td>Markdown export</td><td>Available</td><td>Stable</td></tr><tr><td>HTML export</td><td>Proposed</td><td>Next</td></tr></tbody></table>
+        <div class="action-row"><button class="ghost-action">Regenerate</button><button class="ghost-action">Export HTML</button><button class="ghost-action">Export MD</button></div></div>`
+      },
+      quiz: {
+        title: 'Quiz Focus View',
+        body: `<p><strong>Question 1 / 5</strong></p><p>What role does measurement backaction play in conditioned stochastic dynamics?</p>
+        <div class="option">It removes the stochastic term entirely.</div><div class="option selected">It updates the state estimate based on the measurement record.</div><div class="option">It makes all trajectories deterministic.</div>
+        <div class="action-row"><button class="ghost-action">Confirm</button><button class="ghost-action">Skip</button></div>`
+      },
+      flashcards: {
+        title: 'Flashcards Focus View',
+        body: `<p>Dashboard shows deck readiness. Focus mode is where the actual flip-card study session happens.</p>
+        <div class="mini-report" style="min-height:140px;display:grid;place-items:center;text-align:center;font-size:16px;">What is the difference between ensemble noise and measurement backaction?</div>
+        <div class="action-row"><button class="ghost-action">Flip</button><button class="ghost-action">Next</button><button class="ghost-action">Shuffle</button></div>`
+      },
+      audio: {
+        title: 'Audio Focus View',
+        body: `<p>Audio should be generated from selected Tome sources, not freeform podcast improv.</p>
+        <div class="audio-controls"><button class="ghost-action">−15s</button><button class="round">▶</button><button class="ghost-action">+15s</button></div>
+        <div class="progress"><span style="width:34%"></span></div>
+        <div class="transcript">Transcript preview: Today we are looking at how weak measurement changes the effective stochastic evolution of a Bose-Einstein condensate...</div>`
+      }
+    };
+
+    function showFocus(name) {
+      const view = views[name] || views.chat;
+      focusTitle.textContent = view.title;
+      focusBody.innerHTML = view.body;
+      dashboard.style.display = 'none';
+      focusPanel.classList.add('visible');
+      overlay.classList.remove('visible');
+    }
+    function showDashboard() {
+      focusPanel.classList.remove('visible');
+      dashboard.style.display = 'block';
+    }
+    function openCommand() {
+      overlay.classList.add('visible');
+      setTimeout(() => spotInput.focus(), 40);
+    }
+    function closeCommand() { overlay.classList.remove('visible'); }
+
+    document.querySelectorAll('[data-focus]').forEach(el => {
+      el.addEventListener('click', (e) => {
+        const focus = e.currentTarget.getAttribute('data-focus');
+        showFocus(focus);
+      });
+    });
+    document.getElementById('backDashboard').addEventListener('click', showDashboard);
+    document.getElementById('openCommand').addEventListener('click', openCommand);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeCommand(); });
+    document.addEventListener('keydown', (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); openCommand(); }
+      if (e.key === 'Escape') closeCommand();
+      if (e.key === 'Enter' && overlay.classList.contains('visible')) { showFocus('report'); }
+    });
+  </script>
+</body>
+</html>

--- a/designs/tome-dashboard-proposal.html
+++ b/designs/tome-dashboard-proposal.html
@@ -244,14 +244,28 @@
     .metric strong { display: block; font-size: 20px; letter-spacing: -.02em; }
     .metric span { color: rgba(194,198,214,.58); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
 
+    .layout-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 0 24px 16px;
+      color: rgba(194,198,214,.62);
+      font-size: 12px;
+    }
+    .layout-toolbar strong { color: var(--on-surface); font-weight: 600; }
     .card-grid {
+      --cell: 92px;
       display: grid;
-      grid-template-columns: 1.15fr .85fr;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-auto-rows: var(--cell);
+      grid-auto-flow: dense;
       gap: 12px;
       padding: 0 18px 18px;
+      min-height: 520px;
     }
     .card {
-      min-height: 154px;
+      min-height: 0;
       padding: 17px;
       border: 0;
       border-radius: 22px;
@@ -259,12 +273,58 @@
       box-shadow: inset 0 0 0 1px rgba(66,71,84,.12);
       color: var(--on-surface);
       text-align: left;
-      transition: transform .16s, background .16s, box-shadow .16s;
+      transition: transform .16s, background .16s, box-shadow .16s, opacity .16s;
       position: relative;
       overflow: hidden;
+      grid-column: span var(--col-span, 2);
+      grid-row: span var(--row-span, 2);
+      user-select: none;
     }
     .card:hover { transform: translateY(-2px); background: color-mix(in srgb, var(--surface-container-high) 76%, transparent); box-shadow: inset 0 0 0 1px rgba(173,198,255,.18), 0 8px 24px rgba(0,0,0,.22); }
-    .wide { grid-column: span 1; min-height: 202px; }
+    .card.is-dragging { opacity: .38; transform: scale(.985); }
+    .card.drag-over { box-shadow: inset 0 0 0 1px rgba(173,198,255,.38), 0 0 0 4px rgba(173,198,255,.08); }
+    .card.is-resizing { box-shadow: inset 0 0 0 1px rgba(255,183,134,.42), 0 0 0 4px rgba(255,183,134,.08); }
+    .card.compact .source-list, .card.compact .quote, .card.compact .study-split { display: none; }
+    .card.compact .action-row { margin-top: 10px; }
+    .card.wide { --col-span: 3; --row-span: 2; }
+    .drag-handle {
+      position: absolute;
+      right: 44px;
+      top: 12px;
+      width: 26px;
+      height: 26px;
+      display: grid;
+      place-items: center;
+      border-radius: 9px;
+      color: rgba(194,198,214,.42);
+      background: rgba(14,14,14,.18);
+      cursor: grab;
+      z-index: 2;
+    }
+    .drag-handle:active { cursor: grabbing; }
+    .resize-grip {
+      position: absolute;
+      right: 10px;
+      bottom: 10px;
+      width: 22px;
+      height: 22px;
+      border: 0;
+      border-radius: 8px;
+      background: linear-gradient(135deg, transparent 46%, rgba(173,198,255,.45) 48%, rgba(173,198,255,.45) 56%, transparent 58%),
+                  linear-gradient(135deg, transparent 62%, rgba(173,198,255,.28) 64%, rgba(173,198,255,.28) 72%, transparent 74%);
+      cursor: nwse-resize;
+      opacity: .72;
+      z-index: 2;
+    }
+    .resize-readout {
+      position: absolute;
+      right: 40px;
+      bottom: 12px;
+      color: rgba(194,198,214,.44);
+      font-size: 10px;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
     .card-head { display: flex; justify-content: space-between; align-items: start; gap: 10px; margin-bottom: 12px; }
     .card h3 { margin: 0; font-size: 16px; letter-spacing: -.015em; }
     .card small { color: rgba(194,198,214,.55); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
@@ -373,7 +433,9 @@
     }
     @media (max-width: 720px) {
       .metrics { grid-template-columns: repeat(2, 1fr); }
-      .card-grid { grid-template-columns: 1fr; }
+      .card-grid { grid-template-columns: 1fr; grid-auto-rows: minmax(120px, auto); }
+      .card { grid-column: span 1 !important; grid-row: span 2; }
+      .drag-handle, .resize-grip, .resize-readout, .layout-toolbar { display: none; }
       .dash-hero { grid-template-columns: 1fr; }
       .hero-actions { justify-content: start; }
       .provider { display: none; }
@@ -409,9 +471,11 @@
 
       <h2>Try the prototype</h2>
       <ul>
-        <li>Click Dashboard cards to switch focus views.</li>
+        <li>Drag a card by its handle to rearrange the Dashboard.</li>
+        <li>Drag the corner grip to resize a card across the responsive grid.</li>
+        <li>Click card content to switch focus views.</li>
         <li>Click the compact command bar or press <span class="kbd">⌘</span>/<span class="kbd">Ctrl</span> + <span class="kbd">K</span>.</li>
-        <li>Use the quick-action pills to see how common actions stay visible without natural language.</li>
+        <li>Use Reset layout to return to the Great Sage default.</li>
       </ul>
     </aside>
 
@@ -451,8 +515,16 @@
             <div class="metric"><strong>3</strong><span>stale artifacts</span></div>
           </div>
 
-          <div class="card-grid">
-            <button class="card wide" data-focus="sources">
+          <div class="layout-toolbar">
+            <span><strong>Customizable canvas</strong> · drag handles move cards, corner grips resize them</span>
+            <button class="pill-btn" id="resetLayout" type="button">Reset layout</button>
+          </div>
+
+          <div class="card-grid" id="dashboardGrid">
+            <article class="card wide" data-widget="sources" data-focus="sources" tabindex="0" role="button" style="--col-span: 3; --row-span: 3;">
+              <span class="drag-handle" draggable="true" aria-label="Move Sources card">⋮⋮</span>
+              <span class="resize-readout">3×3</span>
+              <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Grounding</small><h3>Sources</h3></div><span class="badge good">Current</span></div>
               <p>12 documents are active in this Tome. New source additions should mark report, quiz, and audio as stale until regenerated.</p>
               <div class="source-list">
@@ -461,42 +533,57 @@
                 <div class="source-item"><span class="source-icon">url</span> Numerical methods comparison</div>
               </div>
               <div class="action-row"><span class="ghost-action">Manage sources</span><span class="ghost-action">Upload</span></div>
-            </button>
+            </article>
 
-            <button class="card" data-focus="chat">
+            <article class="card" data-widget="chat" data-focus="chat" tabindex="0" role="button" style="--col-span: 1; --row-span: 2;">
+              <span class="drag-handle" draggable="true" aria-label="Move Chat card">⋮⋮</span>
+              <span class="resize-readout">1×2</span>
+              <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Recent thread</small><h3>Chat</h3></div><span class="badge">Resume</span></div>
               <p>Last question: “How does weak measurement change the stochastic noise term?”</p>
               <p class="quote">Answer preview: measurement backaction appears as a conditioned update...</p>
               <div class="action-row"><span class="ghost-action">Continue</span></div>
-            </button>
+            </article>
 
-            <button class="card" data-focus="report">
+            <article class="card" data-widget="report" data-focus="report" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
+              <span class="drag-handle" draggable="true" aria-label="Move Report card">⋮⋮</span>
+              <span class="resize-readout">2×2</span>
+              <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Synthesis artifact</small><h3>Report</h3></div><span class="badge warn">Stale</span></div>
               <div class="mini-report">Latest report covers 9/12 current sources. HTML-first export could preserve tables, citations, and layout better than Markdown alone.</div>
               <div class="action-row"><span class="ghost-action">Open</span><span class="ghost-action">Regenerate</span><span class="ghost-action">Export</span></div>
-            </button>
+            </article>
 
-            <button class="card" data-focus="quiz">
+            <article class="card" data-widget="quiz" data-focus="quiz" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
+              <span class="drag-handle" draggable="true" aria-label="Move Quiz card">⋮⋮</span>
+              <span class="resize-readout">2×2</span>
+              <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Study loop</small><h3>Quiz</h3></div><span class="badge">82% last score</span></div>
               <p>Five-question check generated from core source chunks. Three new sources were added since the last run.</p>
               <div class="progress"><span style="width:82%"></span></div>
               <div class="action-row"><span class="ghost-action">Start quiz</span><span class="ghost-action">Regenerate harder</span></div>
-            </button>
+            </article>
 
-            <button class="card" data-focus="flashcards">
+            <article class="card" data-widget="flashcards" data-focus="flashcards" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
+              <span class="drag-handle" draggable="true" aria-label="Move Flashcards card">⋮⋮</span>
+              <span class="resize-readout">2×2</span>
+              <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Review deck</small><h3>Flashcards</h3></div><span class="badge good">38 cards</span></div>
               <div class="study-split">
                 <div class="study-box"><strong>14</strong><span>due today</span></div>
                 <div class="study-box"><strong>6</strong><span>need source refresh</span></div>
               </div>
               <div class="action-row"><span class="ghost-action">Review</span><span class="ghost-action">Add from new sources</span></div>
-            </button>
+            </article>
 
-            <button class="card" data-focus="audio">
+            <article class="card" data-widget="audio" data-focus="audio" tabindex="0" role="button" style="--col-span: 2; --row-span: 2;">
+              <span class="drag-handle" draggable="true" aria-label="Move Audio card">⋮⋮</span>
+              <span class="resize-readout">2×2</span>
+              <span class="resize-grip" aria-hidden="true"></span>
               <div class="card-head"><div><small>Listen mode</small><h3>Audio Review</h3></div><span class="badge warn">Missing</span></div>
               <p>No audio review exists for the current source set. Future option: single narrator, two-person explainer, or panel discussion.</p>
               <div class="action-row"><span class="ghost-action">Generate audio</span><span class="ghost-action">Panel mode later</span></div>
-            </button>
+            </article>
           </div>
         </section>
 
@@ -598,12 +685,144 @@
     }
     function closeCommand() { overlay.classList.remove('visible'); }
 
-    document.querySelectorAll('[data-focus]').forEach(el => {
+    const grid = document.getElementById('dashboardGrid');
+    const resetLayout = document.getElementById('resetLayout');
+    const layoutKey = 'sage-dashboard-layout-v2';
+    let draggedCard = null;
+    let resizing = null;
+
+    const defaults = Array.from(grid.querySelectorAll('.card')).map(card => ({
+      id: card.dataset.widget,
+      col: Number.parseInt(card.style.getPropertyValue('--col-span')) || 2,
+      row: Number.parseInt(card.style.getPropertyValue('--row-span')) || 2,
+    }));
+
+    function updateCardChrome(card) {
+      const col = Number.parseInt(card.style.getPropertyValue('--col-span')) || 2;
+      const row = Number.parseInt(card.style.getPropertyValue('--row-span')) || 2;
+      card.querySelector('.resize-readout').textContent = `${col}×${row}`;
+      card.classList.toggle('compact', col <= 1 || row <= 1);
+    }
+
+    function saveLayout() {
+      const layout = Array.from(grid.querySelectorAll('.card')).map(card => ({
+        id: card.dataset.widget,
+        col: Number.parseInt(card.style.getPropertyValue('--col-span')) || 2,
+        row: Number.parseInt(card.style.getPropertyValue('--row-span')) || 2,
+      }));
+      localStorage.setItem(layoutKey, JSON.stringify(layout));
+    }
+
+    function loadLayout() {
+      const saved = JSON.parse(localStorage.getItem(layoutKey) || 'null');
+      const layout = Array.isArray(saved) ? saved : defaults;
+      layout.forEach(item => {
+        const card = grid.querySelector(`[data-widget="${item.id}"]`);
+        if (!card) return;
+        card.style.setProperty('--col-span', Math.max(1, Math.min(4, item.col || 2)));
+        card.style.setProperty('--row-span', Math.max(1, Math.min(4, item.row || 2)));
+        grid.appendChild(card);
+        updateCardChrome(card);
+      });
+    }
+
+    function resetLayoutToDefault() {
+      localStorage.removeItem(layoutKey);
+      defaults.forEach(item => {
+        const card = grid.querySelector(`[data-widget="${item.id}"]`);
+        card.style.setProperty('--col-span', item.col);
+        card.style.setProperty('--row-span', item.row);
+        grid.appendChild(card);
+        updateCardChrome(card);
+      });
+    }
+
+    grid.querySelectorAll('.card').forEach(card => {
+      const handle = card.querySelector('.drag-handle');
+      const grip = card.querySelector('.resize-grip');
+
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('.drag-handle, .resize-grip, .ghost-action')) return;
+        showFocus(card.dataset.focus);
+      });
+      card.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') showFocus(card.dataset.focus);
+      });
+
+      handle.addEventListener('dragstart', (e) => {
+        draggedCard = card;
+        card.classList.add('is-dragging');
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', card.dataset.widget);
+      });
+      handle.addEventListener('dragend', () => {
+        card.classList.remove('is-dragging');
+        grid.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
+        draggedCard = null;
+        saveLayout();
+      });
+      card.addEventListener('dragover', (e) => {
+        if (!draggedCard || draggedCard === card) return;
+        e.preventDefault();
+        card.classList.add('drag-over');
+      });
+      card.addEventListener('dragleave', () => card.classList.remove('drag-over'));
+      card.addEventListener('drop', (e) => {
+        e.preventDefault();
+        card.classList.remove('drag-over');
+        if (!draggedCard || draggedCard === card) return;
+        const cards = Array.from(grid.querySelectorAll('.card'));
+        const from = cards.indexOf(draggedCard);
+        const to = cards.indexOf(card);
+        grid.insertBefore(draggedCard, from < to ? card.nextSibling : card);
+        saveLayout();
+      });
+
+      grip.addEventListener('pointerdown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const rect = card.getBoundingClientRect();
+        resizing = {
+          card,
+          startX: e.clientX,
+          startY: e.clientY,
+          startCol: Number.parseInt(card.style.getPropertyValue('--col-span')) || 2,
+          startRow: Number.parseInt(card.style.getPropertyValue('--row-span')) || 2,
+          cellW: rect.width / (Number.parseInt(card.style.getPropertyValue('--col-span')) || 2),
+          cellH: rect.height / (Number.parseInt(card.style.getPropertyValue('--row-span')) || 2),
+        };
+        card.classList.add('is-resizing');
+        grip.setPointerCapture(e.pointerId);
+      });
+    });
+
+    document.addEventListener('pointermove', (e) => {
+      if (!resizing) return;
+      const dx = Math.round((e.clientX - resizing.startX) / Math.max(resizing.cellW, 80));
+      const dy = Math.round((e.clientY - resizing.startY) / Math.max(resizing.cellH, 80));
+      const nextCol = Math.max(1, Math.min(4, resizing.startCol + dx));
+      const nextRow = Math.max(1, Math.min(4, resizing.startRow + dy));
+      resizing.card.style.setProperty('--col-span', nextCol);
+      resizing.card.style.setProperty('--row-span', nextRow);
+      updateCardChrome(resizing.card);
+    });
+
+    document.addEventListener('pointerup', () => {
+      if (!resizing) return;
+      resizing.card.classList.remove('is-resizing');
+      saveLayout();
+      resizing = null;
+    });
+
+    document.querySelectorAll('.hero-actions [data-focus], .spot-row[data-focus]').forEach(el => {
       el.addEventListener('click', (e) => {
         const focus = e.currentTarget.getAttribute('data-focus');
         showFocus(focus);
       });
     });
+    resetLayout.addEventListener('click', resetLayoutToDefault);
+    loadLayout();
+
     document.getElementById('backDashboard').addEventListener('click', showDashboard);
     document.getElementById('openCommand').addEventListener('click', openCommand);
     overlay.addEventListener('click', (e) => { if (e.target === overlay) closeCommand(); });

--- a/designs/tome-home-proposal.html
+++ b/designs/tome-home-proposal.html
@@ -1,0 +1,517 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sage Tome Home Proposal</title>
+  <style>
+    :root {
+      --bg: #080807;
+      --panel: #11110f;
+      --panel-2: #171612;
+      --panel-3: #1d1b16;
+      --ink: #ede6d5;
+      --muted: #9f9788;
+      --faint: #6f675b;
+      --line: rgba(237, 230, 213, 0.1);
+      --line-strong: rgba(237, 230, 213, 0.18);
+      --accent: #f2a85d;
+      --accent-2: #d8b978;
+      --sage: #abc7ad;
+      --danger: #f08a8a;
+      --radius-lg: 30px;
+      --radius-md: 20px;
+      --radius-sm: 999px;
+      --shadow: 0 30px 90px rgba(0,0,0,.42);
+      --ease: cubic-bezier(.2,.8,.2,1);
+    }
+
+    * { box-sizing: border-box; }
+    html { background: var(--bg); color: var(--ink); }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at 50% -10%, rgba(242, 168, 93, .12), transparent 36rem),
+        radial-gradient(circle at 80% 16%, rgba(171, 199, 173, .08), transparent 28rem),
+        linear-gradient(180deg, #0b0a09 0%, #070706 100%);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    button, textarea { font: inherit; }
+    button { cursor: pointer; }
+
+    .shell {
+      width: min(1180px, calc(100vw - 36px));
+      margin: 0 auto;
+      padding: 42px 0 80px;
+    }
+
+    .topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 18px;
+      margin-bottom: 28px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--muted);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      font-size: 12px;
+    }
+
+    .mark {
+      width: 28px;
+      height: 28px;
+      display: grid;
+      place-items: center;
+      color: var(--accent);
+      background: rgba(242,168,93,.08);
+      border: 1px solid rgba(242,168,93,.18);
+      border-radius: 50%;
+    }
+
+    .nav-pills {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px;
+      border: 1px solid var(--line);
+      background: rgba(17,17,15,.7);
+      border-radius: var(--radius-sm);
+      backdrop-filter: blur(18px);
+    }
+
+    .nav-pills button {
+      border: 0;
+      color: var(--muted);
+      background: transparent;
+      border-radius: var(--radius-sm);
+      padding: 9px 13px;
+      transition: color .18s var(--ease), background .18s var(--ease);
+    }
+
+    .nav-pills button.active {
+      color: var(--ink);
+      background: rgba(237,230,213,.08);
+    }
+
+    .hero {
+      min-height: 610px;
+      display: grid;
+      place-items: center;
+      padding: 36px 0 52px;
+    }
+
+    .home-card {
+      width: min(820px, 100%);
+      text-align: center;
+      transition: transform .3s var(--ease), opacity .3s var(--ease);
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 18px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .orb {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--sage);
+      box-shadow: 0 0 22px rgba(171,199,173,.58);
+    }
+
+    h1 {
+      margin: 0;
+      font-family: Georgia, "Times New Roman", serif;
+      font-weight: 400;
+      letter-spacing: -.04em;
+      font-size: clamp(42px, 7vw, 84px);
+      line-height: .96;
+    }
+
+    .subtitle {
+      margin: 18px auto 28px;
+      max-width: 650px;
+      color: var(--muted);
+      font-size: 16px;
+      line-height: 1.65;
+    }
+
+    .tome-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      margin-bottom: 18px;
+      border-radius: var(--radius-sm);
+      background: rgba(237,230,213,.055);
+      border: 1px solid var(--line);
+      color: var(--ink);
+      font-size: 14px;
+    }
+
+    .tome-chip span:last-child { color: var(--muted); }
+
+    .composer {
+      position: relative;
+      text-align: left;
+      background: linear-gradient(180deg, rgba(31,29,24,.96), rgba(19,18,16,.96));
+      border: 1px solid var(--line-strong);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow), inset 0 1px 0 rgba(255,255,255,.045);
+      overflow: hidden;
+    }
+
+    .composer textarea {
+      width: 100%;
+      min-height: 156px;
+      resize: none;
+      border: 0;
+      outline: none;
+      padding: 28px 30px 66px;
+      color: var(--ink);
+      background: transparent;
+      font-size: 18px;
+      line-height: 1.55;
+    }
+
+    .composer textarea::placeholder { color: #70695e; }
+
+    .composer-footer {
+      position: absolute;
+      left: 18px;
+      right: 18px;
+      bottom: 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      color: var(--faint);
+      font-size: 13px;
+    }
+
+    .icon-btn, .model-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      height: 34px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: rgba(0,0,0,.15);
+      color: var(--muted);
+      padding: 0 12px;
+    }
+
+    .capabilities {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 18px auto 0;
+    }
+
+    .capability {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      min-height: 42px;
+      padding: 0 15px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: rgba(237,230,213,.055);
+      color: var(--muted);
+      transition: transform .18s var(--ease), color .18s var(--ease), border .18s var(--ease), background .18s var(--ease);
+    }
+
+    .capability:hover {
+      transform: translateY(-2px);
+      color: var(--ink);
+      border-color: rgba(242,168,93,.28);
+      background: rgba(242,168,93,.08);
+    }
+
+    .capability .icon { color: var(--accent-2); }
+
+    .below-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 22px;
+      color: var(--faint);
+      background: transparent;
+      border: 0;
+      padding: 8px 10px;
+    }
+
+    .proposal-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(320px, .95fr);
+      gap: 18px;
+      margin-top: 10px;
+    }
+
+    .panel {
+      background: rgba(17,17,15,.72);
+      border: 1px solid var(--line);
+      border-radius: 26px;
+      padding: 22px;
+      box-shadow: 0 20px 70px rgba(0,0,0,.24);
+    }
+
+    .panel h2, .panel h3 { margin: 0; font-weight: 520; letter-spacing: -.02em; }
+    .panel h2 { font-size: 24px; }
+    .panel h3 { font-size: 16px; }
+    .panel p { color: var(--muted); line-height: 1.65; margin: 10px 0 0; }
+
+    .decision {
+      display: grid;
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .decision-row {
+      display: grid;
+      grid-template-columns: 112px 1fr;
+      gap: 14px;
+      padding: 14px;
+      border-radius: 18px;
+      background: rgba(237,230,213,.04);
+      border: 1px solid rgba(237,230,213,.07);
+    }
+
+    .decision-row strong { color: var(--ink); }
+    .decision-row span { color: var(--muted); line-height: 1.5; }
+
+    .mini-dashboard {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .mini-card {
+      min-height: 94px;
+      padding: 14px;
+      border-radius: 18px;
+      background: rgba(237,230,213,.045);
+      border: 1px solid rgba(237,230,213,.075);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+
+    .mini-card b { font-size: 14px; }
+    .mini-card small { color: var(--faint); line-height: 1.45; }
+
+    .badge {
+      width: fit-content;
+      padding: 5px 8px;
+      border-radius: var(--radius-sm);
+      color: var(--sage);
+      background: rgba(171,199,173,.08);
+      border: 1px solid rgba(171,199,173,.16);
+      font-size: 11px;
+    }
+
+    .bad { color: var(--danger); background: rgba(240,138,138,.08); border-color: rgba(240,138,138,.18); }
+    .warn { color: var(--accent-2); background: rgba(216,185,120,.08); border-color: rgba(216,185,120,.18); }
+
+    .view { display: none; animation: fade .24s var(--ease); }
+    .view.active { display: block; }
+    @keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+
+    .focus-preview {
+      margin-top: 18px;
+      border-radius: 24px;
+      border: 1px solid var(--line);
+      background: linear-gradient(180deg, rgba(26,25,21,.92), rgba(14,14,12,.92));
+      overflow: hidden;
+    }
+
+    .focus-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .focus-body { padding: 20px; }
+    .report-line { height: 10px; background: rgba(237,230,213,.09); border-radius: 99px; margin: 12px 0; }
+    .report-line:nth-child(2) { width: 88%; }
+    .report-line:nth-child(3) { width: 73%; }
+    .report-line:nth-child(4) { width: 56%; }
+
+    .recommendation {
+      margin-top: 18px;
+      padding: 18px;
+      border-radius: 22px;
+      background: rgba(242,168,93,.075);
+      border: 1px solid rgba(242,168,93,.18);
+    }
+
+    .recommendation strong { color: var(--accent-2); }
+
+    @media (max-width: 860px) {
+      .topbar { align-items: flex-start; flex-direction: column; }
+      .proposal-grid { grid-template-columns: 1fr; }
+      .hero { min-height: auto; padding-top: 28px; }
+      .composer textarea { min-height: 132px; }
+    }
+
+    @media (max-width: 560px) {
+      .shell { width: min(100% - 24px, 1180px); padding-top: 22px; }
+      .nav-pills { width: 100%; overflow: auto; justify-content: flex-start; }
+      .mini-dashboard { grid-template-columns: 1fr; }
+      .composer-footer { position: static; padding: 0 14px 14px; }
+      .composer textarea { padding: 22px 20px 18px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div class="brand"><span class="mark">✦</span><span>Sage · Tome Surface Proposal</span></div>
+      <nav class="nav-pills" aria-label="Proposal views">
+        <button class="active" data-view="home">Tome Home</button>
+        <button data-view="dashboard">Expanded Dashboard</button>
+        <button data-view="rationale">Recommendation</button>
+      </nav>
+    </header>
+
+    <section id="home" class="view active">
+      <div class="hero">
+        <div class="home-card">
+          <div class="eyebrow"><span class="orb"></span><span>Default after Tome selection</span></div>
+          <h1>Good afternoon, zeap.</h1>
+          <p class="subtitle">The default Sage surface should feel like a calm invocation space: Tome-aware, command-first, and capability-revealing without showing every artifact at once.</p>
+          <div class="tome-chip"><span>Selected Tome</span><strong>Weak Measurement in BECs</strong><span>12 sources · active today</span></div>
+
+          <div class="composer">
+            <textarea placeholder="Ask Sage about this Tome, or type / for Tome skills"></textarea>
+            <div class="composer-footer">
+              <button class="icon-btn" aria-label="Add source">＋</button>
+              <div class="model-pill">Local / Cloud Adaptive ▾ <span aria-hidden="true">│</span> 🎙</div>
+            </div>
+          </div>
+
+          <div class="capabilities" aria-label="Tome capabilities">
+            <button class="capability" data-view="dashboard"><span class="icon">▤</span> Sources</button>
+            <button class="capability" data-view="dashboard"><span class="icon">✎</span> Report</button>
+            <button class="capability" data-view="dashboard"><span class="icon">?</span> Quiz</button>
+            <button class="capability" data-view="dashboard"><span class="icon">◇</span> Flashcards</button>
+            <button class="capability" data-view="dashboard"><span class="icon">♪</span> Audio</button>
+            <button class="capability" data-view="dashboard"><span class="icon">⌁</span> Chat</button>
+          </div>
+
+          <button class="below-link" data-view="dashboard">View expanded Tome dashboard →</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="dashboard" class="view">
+      <div class="proposal-grid">
+        <article class="panel">
+          <h2>Expanded Tome Dashboard</h2>
+          <p>This still exists, but it should become a secondary state for inspecting artifact freshness, output status, and generated work. The dashboard is useful. It just should not be the first impression.</p>
+
+          <div class="mini-dashboard">
+            <div class="mini-card"><b>Sources</b><small>12 PDFs and notes indexed</small><span class="badge">Current</span></div>
+            <div class="mini-card"><b>Report</b><small>Generated before 3 new notes were added</small><span class="badge warn">Stale</span></div>
+            <div class="mini-card"><b>Quiz</b><small>5-question test ready from selected Tome</small><span class="badge">Ready</span></div>
+            <div class="mini-card"><b>Audio</b><small>No current audio review for this Tome</small><span class="badge bad">Missing</span></div>
+          </div>
+
+          <div class="focus-preview">
+            <div class="focus-top"><span>Focused component view</span><span>Report → Deep Work</span></div>
+            <div class="focus-body">
+              <div class="report-line"></div>
+              <div class="report-line"></div>
+              <div class="report-line"></div>
+              <p>Clicking a capability chip routes into the full component: report reader, quiz flow, flashcard review, audio player, source manager, or chat.</p>
+            </div>
+          </div>
+        </article>
+
+        <aside class="panel">
+          <h2>What changes?</h2>
+          <div class="decision">
+            <div class="decision-row"><strong>Default</strong><span>Use a centered Tome Home with command box and capability chips.</span></div>
+            <div class="decision-row"><strong>Dashboard</strong><span>Keep as an optional expanded overview, not the primary opening screen.</span></div>
+            <div class="decision-row"><strong>Command</strong><span>Natural language remains primary for expressive intent, but common actions are visible as buttons.</span></div>
+            <div class="decision-row"><strong>Focus</strong><span>Each feature still owns a focused view for real work.</span></div>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="rationale" class="view">
+      <div class="proposal-grid">
+        <article class="panel">
+          <h2>Recommendation</h2>
+          <p>The dashboard direction is conceptually right, but visually too state-heavy as the default. Sage should open like a calm AI research companion, not like an admin dashboard.</p>
+
+          <div class="recommendation">
+            <strong>Great Sage verdict:</strong>
+            Default to <strong>Tome Home</strong>. Preserve <strong>Tome Dashboard</strong> as a secondary expanded state for artifact status and management.
+          </div>
+
+          <div class="decision">
+            <div class="decision-row"><strong>Why</strong><span>The screenshot reference lowers cognitive load while still teaching the user what the product can do.</span></div>
+            <div class="decision-row"><strong>Risk</strong><span>If too minimal, users may miss artifact status. Solve that with subtle freshness badges or an explicit “View dashboard” affordance.</span></div>
+            <div class="decision-row"><strong>MVP</strong><span>Implement Tome Home first: Tome summary, composer, capability chips, focus routing, and a dashboard link.</span></div>
+          </div>
+        </article>
+
+        <aside class="panel">
+          <h2>Component split</h2>
+          <p>Proposed frontend names:</p>
+          <div class="decision">
+            <div class="decision-row"><strong>TomeHome</strong><span>Default calm command center.</span></div>
+            <div class="decision-row"><strong>TomeDashboard</strong><span>Secondary stateful overview.</span></div>
+            <div class="decision-row"><strong>CommandBar</strong><span>Summonable Spotlight-style power surface.</span></div>
+            <div class="decision-row"><strong>Focus Views</strong><span>Report, Quiz, Flashcards, Audio, Sources, Chat.</span></div>
+          </div>
+        </aside>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const buttons = document.querySelectorAll('[data-view]');
+    const navButtons = document.querySelectorAll('.nav-pills [data-view]');
+    const views = document.querySelectorAll('.view');
+
+    function showView(name) {
+      views.forEach(view => view.classList.toggle('active', view.id === name));
+      navButtons.forEach(button => button.classList.toggle('active', button.dataset.view === name));
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    buttons.forEach(button => {
+      button.addEventListener('click', () => showView(button.dataset.view));
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        document.querySelector('.composer textarea')?.focus();
+        showView('home');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/docs/PRODUCT_SURFACES.md
+++ b/docs/PRODUCT_SURFACES.md
@@ -1,0 +1,45 @@
+# Sage Product Surfaces
+
+This note is shared context for humans and agents working on Sage UI/product direction.
+
+## Current decision
+
+Sage is **macOS desktop-first** for the near term. The app is implemented with Tauri + Next.js + FastAPI, but product decisions should optimize for the macOS desktop experience before hosted web or other desktop targets.
+
+## Surface hierarchy
+
+Sage has three complementary UI layers:
+
+1. **Tome Home**
+   - Default in-app landing surface after opening Sage or selecting a Tome.
+   - Calm, centered, composer-first, and Tome-aware.
+   - Shows selected Tome context, a large composer, and capability chips.
+   - Routes users to focused work without opening on a dense dashboard.
+
+2. **Global Command Bar**
+   - Future Spotlight/Raycast-style macOS overlay.
+   - Invoked by global hotkey or tray/menu affordance.
+   - Used for quick capture, search, opening Tomes, and launching skills from anywhere on the OS.
+   - It should be transient and lightweight. Deeper work should route into Tome Home or focused views.
+
+3. **Focused Views**
+   - Deep-work surfaces for Chat, Report, Quiz, Flashcards, Audio, History, Sources/Tomes, and future skills.
+   - These are the main targets for backend skill results.
+
+## Tome Dashboard role
+
+The expanded Tome Dashboard is still useful, but it is **secondary**. Use it for artifact status, source freshness, generated output management, and overview tasks. It should not be the first impression.
+
+## Web scope
+
+A browser-rendered Next.js frontend is useful for development, but a hosted or user-facing web product is out of scope for now. A real web version would require separate decisions around auth, sync, privacy, file access, local runtime/model integration, and deployment.
+
+## Agent guidance
+
+When changing Sage UI:
+
+- Preserve Tome Home as the default app surface.
+- Do not collapse the command-bar idea into Tome Home. Treat the command bar as a separate macOS overlay layer.
+- Keep the dashboard reachable but secondary.
+- Prefer small, focused PRs. `frontend/src/app/page.tsx` is an overlap-prone file, so coordinate on PRs that touch it.
+- Use `npm run build` from `frontend/` after frontend changes.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -187,8 +187,8 @@ function TomeHome({ onSubmit, onNavigate }: { onSubmit: (text: string) => void; 
     <section className="grid min-h-[calc(100vh-8rem)] place-items-center pb-16 pt-4">
       <div className="w-full max-w-[820px] text-center">
         <div className="mb-5 inline-flex items-center gap-2 text-sm text-[#9f9788]">
-          <span className="h-2.5 w-2.5 rounded-full bg-[#abc7ad] shadow-[0_0_22px_rgba(171,199,173,0.58)]" />
-          <span>Tome ready</span>
+          <span className="h-2.5 w-2.5 rounded-full bg-[#d8b978] shadow-[0_0_22px_rgba(216,185,120,0.44)]" />
+          <span>Tome preview</span>
         </div>
 
         <h1 className="font-serif text-[clamp(2.8rem,7vw,5.4rem)] font-normal leading-[0.96] tracking-[-0.05em]">
@@ -202,9 +202,9 @@ function TomeHome({ onSubmit, onNavigate }: { onSubmit: (text: string) => void; 
           onClick={() => onNavigate("tomes")}
           className="mt-7 inline-flex flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-full border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm text-[#ede6d5] transition-colors hover:border-[#f2a85d]/30 hover:bg-[#f2a85d]/10"
         >
-          <span className="text-[#9f9788]">Current Tome</span>
-          <strong className="font-medium">Tome Home</strong>
-          <span className="text-[#9f9788]">ready for research</span>
+          <span className="text-[#9f9788]">Preview Tome</span>
+          <strong className="font-medium">Sample Tome Home</strong>
+          <span className="text-[#9f9788]">placeholder status</span>
         </button>
 
         <form
@@ -269,12 +269,15 @@ function TomeDashboard({ onNavigate }: { onNavigate: (view: ViewState) => void }
         <p className="mt-3 max-w-2xl leading-7 text-[#9f9788]">
           Review sources, generated artifacts, freshness, and recent work for this Tome.
         </p>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-[#d8b978]">
+          Preview statuses shown until Tome selection and generated artifact state are wired.
+        </p>
 
         <div className="mt-6 grid gap-3 sm:grid-cols-2">
-          <DashboardCard title="Sources" detail="Research notes and uploads indexed" status="Current" tone="good" onClick={() => onNavigate("tomes")} />
-          <DashboardCard title="Report" detail="Generate or revisit the latest study guide" status="Ready" tone="warn" onClick={() => onNavigate("report")} />
-          <DashboardCard title="Quiz" detail="Practice against the selected Tome" status="Ready" tone="good" onClick={() => onNavigate("quiz")} />
-          <DashboardCard title="Audio" detail="Listen to a narrated review" status="Optional" tone="muted" onClick={() => onNavigate("audio")} />
+          <DashboardCard title="Sources" detail="Research notes and uploads indexed" status="Preview" tone="warn" onClick={() => onNavigate("tomes")} />
+          <DashboardCard title="Report" detail="Generate or revisit the latest study guide" status="Preview" tone="warn" onClick={() => onNavigate("report")} />
+          <DashboardCard title="Quiz" detail="Practice against the selected Tome" status="Preview" tone="warn" onClick={() => onNavigate("quiz")} />
+          <DashboardCard title="Audio" detail="Listen to a narrated review" status="Preview" tone="muted" onClick={() => onNavigate("audio")} />
         </div>
 
         <div className="mt-6 overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-b from-[#1a1915]/90 to-[#0e0e0c]/90">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -38,20 +38,22 @@ export default function Home() {
   const handleSubmit = (text: string) => {
     const lower = text.toLowerCase().trim();
 
-    if (lower.includes("quiz")) {
+    if (lower === "/quiz") {
       setViewState("quiz");
-    } else if (lower.includes("flashcard") || lower.includes("flash card")) {
+    } else if (lower === "/flashcards" || lower === "/flashcard") {
       setViewState("flashcards");
-    } else if (lower.includes("audio") || lower.includes("listen") || lower.includes("podcast")) {
+    } else if (lower === "/audio") {
       setViewState("audio");
-    } else if (lower.includes("report") || lower.includes("study guide") || lower.includes("summary")) {
+    } else if (lower === "/report") {
       setViewState("report");
-    } else if (lower.includes("history")) {
+    } else if (lower === "/history") {
       setViewState("history");
-    } else if (lower.includes("dashboard") || lower.includes("status")) {
+    } else if (lower === "/dashboard") {
       setViewState("dashboard");
-    } else if (lower.includes("tome") || lower.includes("collection") || lower.includes("library") || lower.includes("source")) {
+    } else if (lower === "/sources" || lower === "/tomes") {
       setViewState("tomes");
+    } else if (lower === "/chat") {
+      setViewState("chat");
     } else {
       setViewState("chat");
     }
@@ -90,25 +92,25 @@ export default function Home() {
           )}
 
           {viewState === "quiz" && (
-            <FocusShell keyName="quiz" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+            <FocusShell keyName="quiz" variants={cardVariants} transition={cardTransition} onBack={handleBack} previewNote="Preview content until Tome-generated quizzes are connected.">
               <QuizWidget title="Transformers Quiz" questions={SAMPLE_QUESTIONS} />
             </FocusShell>
           )}
 
           {viewState === "flashcards" && (
-            <FocusShell keyName="flashcards" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+            <FocusShell keyName="flashcards" variants={cardVariants} transition={cardTransition} onBack={handleBack} previewNote="Preview content until Tome-generated flashcards are connected.">
               <FlashcardWidget title="Transformer Concepts" cards={SAMPLE_FLASHCARDS} />
             </FocusShell>
           )}
 
           {viewState === "audio" && (
-            <FocusShell keyName="audio" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+            <FocusShell keyName="audio" variants={cardVariants} transition={cardTransition} onBack={handleBack} previewNote="Preview content until Tome-generated audio reviews are connected.">
               <AudioPlayerWidget track={SAMPLE_TRACK} />
             </FocusShell>
           )}
 
           {viewState === "report" && (
-            <FocusShell keyName="report" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+            <FocusShell keyName="report" variants={cardVariants} transition={cardTransition} onBack={handleBack} previewNote="Preview content until Tome-generated reports are connected.">
               <ReportViewWidget report={SAMPLE_REPORT} />
             </FocusShell>
           )}
@@ -186,23 +188,23 @@ function TomeHome({ onSubmit, onNavigate }: { onSubmit: (text: string) => void; 
       <div className="w-full max-w-[820px] text-center">
         <div className="mb-5 inline-flex items-center gap-2 text-sm text-[#9f9788]">
           <span className="h-2.5 w-2.5 rounded-full bg-[#abc7ad] shadow-[0_0_22px_rgba(171,199,173,0.58)]" />
-          <span>Default after Tome selection</span>
+          <span>Tome ready</span>
         </div>
 
         <h1 className="font-serif text-[clamp(2.8rem,7vw,5.4rem)] font-normal leading-[0.96] tracking-[-0.05em]">
           Good afternoon, zeap.
         </h1>
         <p className="mx-auto mt-5 max-w-[650px] text-base leading-7 text-[#9f9788]">
-          A calm Tome-aware command center: ask Sage, reveal common capabilities, and jump into focused work without opening on a heavy dashboard.
+          Ask questions, generate study materials, manage sources, or jump into focused work for this Tome.
         </p>
 
         <button
           onClick={() => onNavigate("tomes")}
           className="mt-7 inline-flex flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-full border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm text-[#ede6d5] transition-colors hover:border-[#f2a85d]/30 hover:bg-[#f2a85d]/10"
         >
-          <span className="text-[#9f9788]">Selected Tome</span>
+          <span className="text-[#9f9788]">Current Tome</span>
           <strong className="font-medium">Tome Home</strong>
-          <span className="text-[#9f9788]">research space · active today</span>
+          <span className="text-[#9f9788]">ready for research</span>
         </button>
 
         <form
@@ -254,7 +256,7 @@ function TomeDashboard({ onNavigate }: { onNavigate: (view: ViewState) => void }
       <article className="rounded-[26px] border border-white/10 bg-[#11110f]/75 p-6 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <p className="text-sm text-[#9f9788]">Secondary overview</p>
+            <p className="text-sm text-[#9f9788]">Tome overview</p>
             <h2 className="mt-1 text-2xl font-medium tracking-[-0.03em] text-[#ede6d5]">Expanded Tome Dashboard</h2>
           </div>
           <button
@@ -265,7 +267,7 @@ function TomeDashboard({ onNavigate }: { onNavigate: (view: ViewState) => void }
           </button>
         </div>
         <p className="mt-3 max-w-2xl leading-7 text-[#9f9788]">
-          This dashboard stays available for artifact freshness, output status, and generated work management. It is useful context, just not the first impression.
+          Review sources, generated artifacts, freshness, and recent work for this Tome.
         </p>
 
         <div className="mt-6 grid gap-3 sm:grid-cols-2">
@@ -292,12 +294,12 @@ function TomeDashboard({ onNavigate }: { onNavigate: (view: ViewState) => void }
       </article>
 
       <aside className="rounded-[26px] border border-white/10 bg-[#11110f]/75 p-6 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
-        <h2 className="text-2xl font-medium tracking-[-0.03em] text-[#ede6d5]">What changed?</h2>
+        <h2 className="text-2xl font-medium tracking-[-0.03em] text-[#ede6d5]">Tome activity</h2>
         <div className="mt-5 grid gap-3">
-          <DecisionRow label="Default" text="A centered Tome Home with command box and capability chips." />
-          <DecisionRow label="Dashboard" text="An optional expanded overview for freshness and artifact management." />
-          <DecisionRow label="Command" text="Natural language stays primary, with visible buttons for common actions." />
-          <DecisionRow label="Focus" text="Each feature still owns a focused deep-work surface." />
+          <DecisionRow label="Sources" text="Manage uploaded notes, papers, and references." />
+          <DecisionRow label="Artifacts" text="Revisit reports, quizzes, flashcards, and audio." />
+          <DecisionRow label="Chat" text="Continue conversations grounded in this Tome." />
+          <DecisionRow label="History" text="Review recent work and generated outputs." />
         </div>
       </aside>
     </section>
@@ -309,21 +311,32 @@ function FocusShell({
   variants,
   transition,
   onBack,
+  previewNote,
   children,
 }: {
   keyName: string;
   variants: Variants;
   transition: Transition;
   onBack: () => void;
+  previewNote?: string;
   children: ReactNode;
 }) {
   return (
     <motion.div key={keyName} variants={variants} initial="initial" animate="animate" exit="exit" transition={transition} className="w-full flex-1">
       <div className="relative z-10 flex w-full flex-col items-center gap-4 pb-16 pt-4">
+        {previewNote && <PreviewNote>{previewNote}</PreviewNote>}
         {children}
         <BackButton onClick={onBack} />
       </div>
     </motion.div>
+  );
+}
+
+function PreviewNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-full max-w-[640px] rounded-full border border-[#d8b978]/15 bg-[#d8b978]/10 px-4 py-2 text-center text-sm text-[#d8b978]">
+      {children}
+    </div>
   );
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import type { FormEvent, KeyboardEvent, ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import CommandBar from "@/components/CommandBar";
+import type { Transition, Variants } from "framer-motion";
 import QuizWidget, { SAMPLE_QUESTIONS } from "@/components/QuizWidget";
 import FlashcardWidget, { SAMPLE_FLASHCARDS } from "@/components/FlashcardWidget";
 import AudioPlayerWidget, { SAMPLE_TRACK } from "@/components/AudioPlayerWidget";
@@ -11,7 +12,25 @@ import HistoryPanel from "@/components/HistoryPanel";
 import TomeSelector from "@/components/TomeSelector";
 import ChatWidget from "@/components/ChatWidget";
 
-type ViewState = "idle" | "quiz" | "flashcards" | "audio" | "report" | "history" | "tomes" | "chat";
+type ViewState =
+  | "idle"
+  | "dashboard"
+  | "quiz"
+  | "flashcards"
+  | "audio"
+  | "report"
+  | "history"
+  | "tomes"
+  | "chat";
+
+const capabilities: Array<{ label: string; icon: string; view: ViewState }> = [
+  { label: "Sources", icon: "▤", view: "tomes" },
+  { label: "Report", icon: "✎", view: "report" },
+  { label: "Quiz", icon: "?", view: "quiz" },
+  { label: "Flashcards", icon: "◇", view: "flashcards" },
+  { label: "Audio", icon: "♪", view: "audio" },
+  { label: "Chat", icon: "⌁", view: "chat" },
+];
 
 export default function Home() {
   const [viewState, setViewState] = useState<ViewState>("idle");
@@ -29,7 +48,9 @@ export default function Home() {
       setViewState("report");
     } else if (lower.includes("history")) {
       setViewState("history");
-    } else if (lower.includes("tome") || lower.includes("collection") || lower.includes("library")) {
+    } else if (lower.includes("dashboard") || lower.includes("status")) {
+      setViewState("dashboard");
+    } else if (lower.includes("tome") || lower.includes("collection") || lower.includes("library") || lower.includes("source")) {
       setViewState("tomes");
     } else {
       setViewState("chat");
@@ -40,101 +61,334 @@ export default function Home() {
     setViewState("idle");
   };
 
-  const cardVariants = {
+  const cardVariants: Variants = {
     initial: { opacity: 0, y: 16, scale: 0.97 },
     animate: { opacity: 1, y: 0, scale: 1 },
     exit: { opacity: 0, y: -10, scale: 0.97 },
   };
 
-  const cardTransition = { duration: 0.28, ease: [0.25, 0.46, 0.45, 0.94] };
+  const cardTransition: Transition = { duration: 0.28, ease: [0.25, 0.46, 0.45, 0.94] };
 
   return (
-    <main className="relative w-full min-h-screen flex flex-col items-center pt-24 pb-12 gap-5">
-      {/* Ambient glow */}
-      <div className="ambient-glow" />
+    <main className="relative min-h-screen w-full overflow-hidden bg-[#080807] text-[#ede6d5]">
+      <div className="pointer-events-none absolute inset-x-0 top-[-12rem] h-[36rem] bg-[radial-gradient(circle_at_center,rgba(242,168,93,0.12),transparent_62%)]" />
+      <div className="pointer-events-none absolute right-[-12rem] top-16 h-[32rem] w-[32rem] rounded-full bg-[rgba(171,199,173,0.07)] blur-[110px]" />
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1180px] flex-col px-5 py-8 sm:px-8 lg:px-10">
+        <TopBar viewState={viewState} onNavigate={setViewState} />
 
-      {/* Command bar — always visible, shifts up when content appears */}
-      <div
-        className={`relative z-10 transition-all duration-500 ease-out ${
-          viewState !== "idle" ? "pt-0" : "pt-8"
-        }`}
-      >
-        <CommandBar onSubmit={handleSubmit} />
+        <AnimatePresence mode="wait">
+          {viewState === "idle" && (
+            <motion.div key="home" {...cardVariants} transition={cardTransition} className="w-full flex-1">
+              <TomeHome onSubmit={handleSubmit} onNavigate={setViewState} />
+            </motion.div>
+          )}
+
+          {viewState === "dashboard" && (
+            <motion.div key="dashboard" {...cardVariants} transition={cardTransition} className="w-full flex-1">
+              <TomeDashboard onNavigate={setViewState} />
+            </motion.div>
+          )}
+
+          {viewState === "quiz" && (
+            <FocusShell keyName="quiz" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <QuizWidget title="Transformers Quiz" questions={SAMPLE_QUESTIONS} />
+            </FocusShell>
+          )}
+
+          {viewState === "flashcards" && (
+            <FocusShell keyName="flashcards" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <FlashcardWidget title="Transformer Concepts" cards={SAMPLE_FLASHCARDS} />
+            </FocusShell>
+          )}
+
+          {viewState === "audio" && (
+            <FocusShell keyName="audio" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <AudioPlayerWidget track={SAMPLE_TRACK} />
+            </FocusShell>
+          )}
+
+          {viewState === "report" && (
+            <FocusShell keyName="report" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <ReportViewWidget report={SAMPLE_REPORT} />
+            </FocusShell>
+          )}
+
+          {viewState === "history" && (
+            <FocusShell keyName="history" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <HistoryPanel />
+            </FocusShell>
+          )}
+
+          {viewState === "tomes" && (
+            <FocusShell keyName="tomes" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <TomeSelector />
+            </FocusShell>
+          )}
+
+          {viewState === "chat" && (
+            <FocusShell keyName="chat" variants={cardVariants} transition={cardTransition} onBack={handleBack}>
+              <ChatWidget />
+            </FocusShell>
+          )}
+        </AnimatePresence>
       </div>
-
-      {/* Content area */}
-      <AnimatePresence mode="wait">
-        {viewState === "quiz" && (
-          <motion.div key="quiz" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <QuizWidget title="Transformers Quiz" questions={SAMPLE_QUESTIONS} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "flashcards" && (
-          <motion.div key="flashcards" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <FlashcardWidget title="Transformer Concepts" cards={SAMPLE_FLASHCARDS} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "audio" && (
-          <motion.div key="audio" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <AudioPlayerWidget track={SAMPLE_TRACK} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "report" && (
-          <motion.div key="report" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <ReportViewWidget report={SAMPLE_REPORT} />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "history" && (
-          <motion.div key="history" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <HistoryPanel />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "tomes" && (
-          <motion.div key="tomes" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <TomeSelector />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-
-        {viewState === "chat" && (
-          <motion.div key="chat" {...cardVariants} transition={cardTransition}
-            className="relative z-10 w-full flex flex-col items-center gap-4">
-            <ChatWidget />
-            <BackButton onClick={handleBack} />
-          </motion.div>
-        )}
-      </AnimatePresence>
     </main>
   );
 }
 
-/** Shared back button */
+function TopBar({ viewState, onNavigate }: { viewState: ViewState; onNavigate: (view: ViewState) => void }) {
+  return (
+    <header className="flex flex-col gap-4 pb-8 sm:flex-row sm:items-center sm:justify-between">
+      <button
+        onClick={() => onNavigate("idle")}
+        className="flex w-fit items-center gap-3 text-left text-[0.72rem] uppercase tracking-[0.16em] text-[#9f9788] transition-colors hover:text-[#ede6d5]"
+      >
+        <span className="grid h-8 w-8 place-items-center rounded-full border border-[#f2a85d]/20 bg-[#f2a85d]/10 text-[#f2a85d]">
+          ✦
+        </span>
+        <span>Sage · Tome Home</span>
+      </button>
+
+      <nav className="flex w-full gap-1 overflow-x-auto rounded-full border border-white/10 bg-[#11110f]/70 p-1 backdrop-blur sm:w-fit">
+        <NavPill active={viewState === "idle"} onClick={() => onNavigate("idle")}>Home</NavPill>
+        <NavPill active={viewState === "dashboard"} onClick={() => onNavigate("dashboard")}>Dashboard</NavPill>
+        <NavPill active={viewState === "history"} onClick={() => onNavigate("history")}>History</NavPill>
+        <NavPill active={viewState === "tomes"} onClick={() => onNavigate("tomes")}>Tomes</NavPill>
+      </nav>
+    </header>
+  );
+}
+
+function TomeHome({ onSubmit, onNavigate }: { onSubmit: (text: string) => void; onNavigate: (view: ViewState) => void }) {
+  const [prompt, setPrompt] = useState("");
+
+  const submitPrompt = () => {
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setPrompt("");
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    submitPrompt();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submitPrompt();
+    }
+  };
+
+  return (
+    <section className="grid min-h-[calc(100vh-8rem)] place-items-center pb-16 pt-4">
+      <div className="w-full max-w-[820px] text-center">
+        <div className="mb-5 inline-flex items-center gap-2 text-sm text-[#9f9788]">
+          <span className="h-2.5 w-2.5 rounded-full bg-[#abc7ad] shadow-[0_0_22px_rgba(171,199,173,0.58)]" />
+          <span>Default after Tome selection</span>
+        </div>
+
+        <h1 className="font-serif text-[clamp(2.8rem,7vw,5.4rem)] font-normal leading-[0.96] tracking-[-0.05em]">
+          Good afternoon, zeap.
+        </h1>
+        <p className="mx-auto mt-5 max-w-[650px] text-base leading-7 text-[#9f9788]">
+          A calm Tome-aware command center: ask Sage, reveal common capabilities, and jump into focused work without opening on a heavy dashboard.
+        </p>
+
+        <button
+          onClick={() => onNavigate("tomes")}
+          className="mt-7 inline-flex flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-full border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm text-[#ede6d5] transition-colors hover:border-[#f2a85d]/30 hover:bg-[#f2a85d]/10"
+        >
+          <span className="text-[#9f9788]">Selected Tome</span>
+          <strong className="font-medium">Tome Home</strong>
+          <span className="text-[#9f9788]">research space · active today</span>
+        </button>
+
+        <form
+          onSubmit={handleSubmit}
+          className="mt-5 overflow-hidden rounded-[30px] border border-white/15 bg-gradient-to-b from-[#1f1d18]/95 to-[#131210]/95 text-left shadow-[0_30px_90px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.045)]"
+        >
+          <textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask Sage about this Tome, or type / for Tome skills"
+            className="min-h-[156px] w-full resize-none border-0 bg-transparent px-6 py-6 pb-4 text-lg leading-7 text-[#ede6d5] outline-none placeholder:text-[#70695e] sm:px-8"
+            spellCheck={false}
+          />
+          <div className="flex flex-col gap-3 px-4 pb-4 text-sm text-[#6f675b] sm:flex-row sm:items-center sm:justify-between sm:px-5">
+            <button
+              type="button"
+              onClick={() => onNavigate("tomes")}
+              className="inline-flex h-9 w-fit items-center gap-2 rounded-full border border-white/10 bg-black/15 px-3 text-[#9f9788] transition-colors hover:border-[#abc7ad]/30 hover:text-[#ede6d5]"
+            >
+              ＋ Add source
+            </button>
+            <div className="inline-flex h-9 w-fit items-center gap-2 rounded-full border border-white/10 bg-black/15 px-3 text-[#9f9788]">
+              Local / Cloud Adaptive <span aria-hidden="true">│</span> 🎙
+            </div>
+          </div>
+        </form>
+
+        <div className="mx-auto mt-5 flex max-w-[740px] flex-wrap justify-center gap-2.5" aria-label="Tome capabilities">
+          {capabilities.map((capability) => (
+            <CapabilityButton key={capability.label} {...capability} onNavigate={onNavigate} />
+          ))}
+        </div>
+
+        <button
+          onClick={() => onNavigate("dashboard")}
+          className="mt-6 rounded-full px-3 py-2 text-sm text-[#6f675b] transition-colors hover:text-[#ede6d5]"
+        >
+          View expanded Tome dashboard →
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function TomeDashboard({ onNavigate }: { onNavigate: (view: ViewState) => void }) {
+  return (
+    <section className="grid gap-5 pb-16 lg:grid-cols-[minmax(0,1.05fr)_minmax(320px,0.95fr)]">
+      <article className="rounded-[26px] border border-white/10 bg-[#11110f]/75 p-6 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm text-[#9f9788]">Secondary overview</p>
+            <h2 className="mt-1 text-2xl font-medium tracking-[-0.03em] text-[#ede6d5]">Expanded Tome Dashboard</h2>
+          </div>
+          <button
+            onClick={() => onNavigate("idle")}
+            className="w-fit rounded-full border border-white/10 px-3 py-1.5 text-sm text-[#9f9788] transition-colors hover:border-[#f2a85d]/30 hover:text-[#ede6d5]"
+          >
+            Back to Tome Home
+          </button>
+        </div>
+        <p className="mt-3 max-w-2xl leading-7 text-[#9f9788]">
+          This dashboard stays available for artifact freshness, output status, and generated work management. It is useful context, just not the first impression.
+        </p>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          <DashboardCard title="Sources" detail="Research notes and uploads indexed" status="Current" tone="good" onClick={() => onNavigate("tomes")} />
+          <DashboardCard title="Report" detail="Generate or revisit the latest study guide" status="Ready" tone="warn" onClick={() => onNavigate("report")} />
+          <DashboardCard title="Quiz" detail="Practice against the selected Tome" status="Ready" tone="good" onClick={() => onNavigate("quiz")} />
+          <DashboardCard title="Audio" detail="Listen to a narrated review" status="Optional" tone="muted" onClick={() => onNavigate("audio")} />
+        </div>
+
+        <div className="mt-6 overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-b from-[#1a1915]/90 to-[#0e0e0c]/90">
+          <div className="flex justify-between gap-3 border-b border-white/10 px-5 py-3 text-sm text-[#9f9788]">
+            <span>Focused component view</span>
+            <span>Report → Deep Work</span>
+          </div>
+          <div className="p-5">
+            <div className="my-3 h-2.5 rounded-full bg-white/10" />
+            <div className="my-3 h-2.5 w-[88%] rounded-full bg-white/10" />
+            <div className="my-3 h-2.5 w-[73%] rounded-full bg-white/10" />
+            <p className="mt-4 leading-7 text-[#9f9788]">
+              Capability chips route into focused views for reports, quizzes, flashcards, audio, sources, and chat.
+            </p>
+          </div>
+        </div>
+      </article>
+
+      <aside className="rounded-[26px] border border-white/10 bg-[#11110f]/75 p-6 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
+        <h2 className="text-2xl font-medium tracking-[-0.03em] text-[#ede6d5]">What changed?</h2>
+        <div className="mt-5 grid gap-3">
+          <DecisionRow label="Default" text="A centered Tome Home with command box and capability chips." />
+          <DecisionRow label="Dashboard" text="An optional expanded overview for freshness and artifact management." />
+          <DecisionRow label="Command" text="Natural language stays primary, with visible buttons for common actions." />
+          <DecisionRow label="Focus" text="Each feature still owns a focused deep-work surface." />
+        </div>
+      </aside>
+    </section>
+  );
+}
+
+function FocusShell({
+  keyName,
+  variants,
+  transition,
+  onBack,
+  children,
+}: {
+  keyName: string;
+  variants: Variants;
+  transition: Transition;
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <motion.div key={keyName} variants={variants} initial="initial" animate="animate" exit="exit" transition={transition} className="w-full flex-1">
+      <div className="relative z-10 flex w-full flex-col items-center gap-4 pb-16 pt-4">
+        {children}
+        <BackButton onClick={onBack} />
+      </div>
+    </motion.div>
+  );
+}
+
+function NavPill({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`whitespace-nowrap rounded-full px-3.5 py-2 text-sm transition-colors ${
+        active ? "bg-white/10 text-[#ede6d5]" : "text-[#9f9788] hover:text-[#ede6d5]"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CapabilityButton({ label, icon, view, onNavigate }: { label: string; icon: string; view: ViewState; onNavigate: (view: ViewState) => void }) {
+  return (
+    <button
+      onClick={() => onNavigate(view)}
+      className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/10 bg-white/[0.055] px-4 text-sm text-[#9f9788] transition-all duration-150 hover:-translate-y-0.5 hover:border-[#f2a85d]/30 hover:bg-[#f2a85d]/10 hover:text-[#ede6d5]"
+    >
+      <span className="text-[#d8b978]">{icon}</span>
+      {label}
+    </button>
+  );
+}
+
+function DashboardCard({ title, detail, status, tone, onClick }: { title: string; detail: string; status: string; tone: "good" | "warn" | "muted"; onClick: () => void }) {
+  const toneClasses = {
+    good: "border-[#abc7ad]/20 bg-[#abc7ad]/10 text-[#abc7ad]",
+    warn: "border-[#d8b978]/20 bg-[#d8b978]/10 text-[#d8b978]",
+    muted: "border-white/10 bg-white/5 text-[#9f9788]",
+  }[tone];
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex min-h-28 flex-col justify-between rounded-[18px] border border-white/[0.075] bg-white/[0.045] p-4 text-left transition-colors hover:border-[#f2a85d]/25 hover:bg-[#f2a85d]/10"
+    >
+      <div>
+        <b className="text-sm text-[#ede6d5]">{title}</b>
+        <p className="mt-2 text-sm leading-6 text-[#6f675b]">{detail}</p>
+      </div>
+      <span className={`mt-3 w-fit rounded-full border px-2 py-1 text-[0.68rem] ${toneClasses}`}>{status}</span>
+    </button>
+  );
+}
+
+function DecisionRow({ label, text }: { label: string; text: string }) {
+  return (
+    <div className="grid gap-2 rounded-[18px] border border-white/[0.07] bg-white/[0.04] p-4 sm:grid-cols-[112px_1fr] sm:gap-4">
+      <strong className="text-[#ede6d5]">{label}</strong>
+      <span className="leading-6 text-[#9f9788]">{text}</span>
+    </div>
+  );
+}
+
 function BackButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       onClick={onClick}
-      className="px-4 py-1.5 rounded-full text-label-sm
-                 border border-outline-variant/15 text-on-surface-variant
-                 hover:border-outline-variant/30 hover:text-on-surface
-                 transition-all duration-150"
+      className="rounded-full border border-white/10 px-4 py-1.5 text-sm text-[#9f9788] transition-all duration-150 hover:border-[#f2a85d]/30 hover:text-[#ede6d5]"
     >
-      ← Back
+      ← Back to Tome Home
     </button>
   );
 }


### PR DESCRIPTION
## Summary

- Makes Tome Home the default Sage dashboard surface.
- Adds focused visual views for sources, reports, quizzes, flashcards, audio, and chat.
- Keeps the expanded Tome Dashboard available as a secondary overview.
- Preserves History and Tomes in the top navigation.
- Uses slash commands for deterministic preview routing.
- Frames the Home composer and focused views as visual/product-surface work in this PR. Live normal-prompt handoff to `ChatWidget`, backend chat round-trips, and generated-content wiring are intentionally left to the frontend integration work in #43.
- Marks sample-backed artifact views and dashboard statuses as previews until Tome selection/generated state is wired.

## Test Plan

- [x] `cd frontend && npm run build`